### PR TITLE
[DEFAULT]

### DIFF
--- a/src/main/java/io/hhplus/concert/concert/domain/Concert.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/Concert.java
@@ -1,0 +1,21 @@
+package io.hhplus.concert.concert.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(length = 100)
+    private String cast;
+}

--- a/src/main/java/io/hhplus/concert/concert/domain/ConcertSchedule.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/ConcertSchedule.java
@@ -1,0 +1,28 @@
+package io.hhplus.concert.concert.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "concert_id")
+        }
+)
+public class ConcertSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long concertId;
+
+    @Column(nullable = false)
+    private LocalDateTime scheduledAt;
+}

--- a/src/main/java/io/hhplus/concert/concert/domain/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/ConcertSeat.java
@@ -1,0 +1,37 @@
+package io.hhplus.concert.concert.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "concert_schedule_id")
+        }
+)
+public class ConcertSeat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long concertScheduleId;
+
+    @Column
+    private String label;
+
+    @Column(nullable = false)
+    private Integer seatNumber;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal price;
+
+    @Column
+    private Boolean isActive = true;
+}

--- a/src/main/java/io/hhplus/concert/concert/domain/Reservation.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/Reservation.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.concert.domain;
+
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "user_id,concert_seat_id")
+        }
+)
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long concertSeatId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus status;
+
+    @Column(nullable = false)
+    private Long paymentId;
+}

--- a/src/main/java/io/hhplus/concert/concert/domain/enm/ReleaseTarget.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/enm/ReleaseTarget.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.concert.domain.enm;
+
+public enum ReleaseTarget {
+    CONCERT, CONCERT_SCHEDULE, CONCERT_SEAT
+}

--- a/src/main/java/io/hhplus/concert/concert/domain/enm/ReservationStatus.java
+++ b/src/main/java/io/hhplus/concert/concert/domain/enm/ReservationStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.concert.domain.enm;
+
+public enum ReservationStatus {
+    PENDING, COMPLETE, CANCELLED
+}

--- a/src/main/java/io/hhplus/concert/concert/port/ConcertPort.java
+++ b/src/main/java/io/hhplus/concert/concert/port/ConcertPort.java
@@ -1,0 +1,27 @@
+package io.hhplus.concert.concert.port;
+
+import io.hhplus.concert.concert.domain.Concert;
+import io.hhplus.concert.concert.port.jpa.ConcertJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@AllArgsConstructor
+@Repository
+public class ConcertPort {
+
+    private final ConcertJpaRepository jpaRepository;
+
+    public Boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
+
+    public Page<Concert> findAllByPageable(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+    public Concert save(Concert concert) {
+        return jpaRepository.save(concert);
+    }
+}

--- a/src/main/java/io/hhplus/concert/concert/port/ConcertSchedulePort.java
+++ b/src/main/java/io/hhplus/concert/concert/port/ConcertSchedulePort.java
@@ -1,6 +1,5 @@
 package io.hhplus.concert.concert.port;
 
-import io.hhplus.concert.concert.domain.Concert;
 import io.hhplus.concert.concert.domain.ConcertSchedule;
 import io.hhplus.concert.concert.port.jpa.ConcertScheduleJpaRepository;
 import lombok.AllArgsConstructor;

--- a/src/main/java/io/hhplus/concert/concert/port/ConcertSchedulePort.java
+++ b/src/main/java/io/hhplus/concert/concert/port/ConcertSchedulePort.java
@@ -1,0 +1,35 @@
+package io.hhplus.concert.concert.port;
+
+import io.hhplus.concert.concert.domain.Concert;
+import io.hhplus.concert.concert.domain.ConcertSchedule;
+import io.hhplus.concert.concert.port.jpa.ConcertScheduleJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class ConcertSchedulePort {
+
+    private final ConcertScheduleJpaRepository jpaRepository;
+
+    public Boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
+
+    public Page<ConcertSchedule> findAllByConcertIdAndPageable(Long concertId, Pageable pageable) {
+        return jpaRepository.findAllByConcertId(concertId, pageable);
+    }
+
+    public List<Long> getAvailableAllIdsByConcertId(Long concertId) {
+        return jpaRepository.findAllIdsByConcertIdAndScheduledAtGreaterThanEqual(concertId, LocalDateTime.now());
+    }
+
+    public ConcertSchedule save(ConcertSchedule concertSchedule) {
+        return jpaRepository.save(concertSchedule);
+    }
+}

--- a/src/main/java/io/hhplus/concert/concert/port/ConcertSeatPort.java
+++ b/src/main/java/io/hhplus/concert/concert/port/ConcertSeatPort.java
@@ -1,0 +1,52 @@
+package io.hhplus.concert.concert.port;
+
+import io.hhplus.concert.concert.domain.ConcertSeat;
+import io.hhplus.concert.concert.port.jpa.ConcertSeatJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class ConcertSeatPort {
+
+    private final ConcertSeatJpaRepository jpaRepository;
+
+    public Boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
+
+    public ConcertSeat get(Long id) {
+        return jpaRepository.findById(id).orElseThrow();
+    }
+
+    public ConcertSeat getWithLock(Long id) {
+        return jpaRepository.findByIdWithLock(id).orElseThrow();
+    }
+
+    public ConcertSeat save(ConcertSeat concertSeat) {
+        return jpaRepository.save(concertSeat);
+    }
+
+    public List<ConcertSeat> saveAll(Collection<ConcertSeat> concertSeats) {
+        return jpaRepository.saveAll(concertSeats);
+    }
+
+    public List<ConcertSeat> getAllByIdsWithLock(List<Long> ids) {
+        return jpaRepository.findAllByIdIn(ids);
+    }
+
+    public List<ConcertSeat> getAllByConcertScheduleIdWithLock(Long concertScheduleId) {
+        return jpaRepository.findAllByConcertScheduleId(concertScheduleId);
+    }
+
+    public List<Long> getAllIdsByConcertScheduleId(Long concertScheduleId) {
+        return jpaRepository.findAllIdsByConcertScheduleId(concertScheduleId);
+    }
+
+    public List<Long> getAllIdsByConcertScheduleIdIn(List<Long> concertScheduleIds) {
+        return jpaRepository.findAllIdsByConcertScheduleIdIn(concertScheduleIds);
+    }
+}

--- a/src/main/java/io/hhplus/concert/concert/port/ReservationPort.java
+++ b/src/main/java/io/hhplus/concert/concert/port/ReservationPort.java
@@ -1,0 +1,44 @@
+package io.hhplus.concert.concert.port;
+
+import io.hhplus.concert.concert.domain.Reservation;
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+import io.hhplus.concert.concert.port.jpa.ReservationJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class ReservationPort {
+
+    private final ReservationJpaRepository jpaRepository;
+
+    public Reservation get(Long id) {
+        return jpaRepository.findById(id).orElseThrow();
+    }
+
+    public Reservation getWithLock(Long id) {
+        return jpaRepository.findByIdWithLock(id).orElseThrow();
+    }
+
+    public Reservation save(Reservation reservation) {
+        return jpaRepository.save(reservation);
+    }
+
+    public List<Reservation> saveAll(List<Reservation> reservations) {
+        return jpaRepository.saveAll(reservations);
+    }
+
+    public List<Long> getAllConcertSeatIdsByConcertSeatIdsWithLock(List<Long> concertSeatIds, List<ReservationStatus> statuses) {
+        return jpaRepository.findAllConcertSeatIdsByConcertSeatIdInAndStatusInWithLock(concertSeatIds, statuses);
+    }
+
+    public List<Reservation> getAllByStatusesWithLock(List<ReservationStatus> statuses) {
+        return jpaRepository.findAllByStatusIn(statuses);
+    }
+
+    public List<Reservation> getAllByConcertSeatIdsAndStatusesWithLock(List<Long> concertSeatIds, List<ReservationStatus> statuses) {
+        return jpaRepository.findAllByConcertSeatIdInAndStatusIn(concertSeatIds, statuses);
+    }
+}

--- a/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertJpaRepository.java
@@ -1,0 +1,9 @@
+package io.hhplus.concert.concert.port.jpa;
+
+import io.hhplus.concert.concert.domain.Concert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConcertJpaRepository extends JpaRepository<Concert, Long> {
+}

--- a/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertScheduleJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertScheduleJpaRepository.java
@@ -1,0 +1,19 @@
+package io.hhplus.concert.concert.port.jpa;
+
+import io.hhplus.concert.concert.domain.ConcertSchedule;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ConcertScheduleJpaRepository extends JpaRepository<ConcertSchedule, Long> {
+
+    Page<ConcertSchedule> findAllByConcertId(Long concertId, Pageable pageable);
+    List<Long> findAllIdsByConcertIdAndScheduledAtGreaterThanEqual(Long concertId, LocalDateTime baseDateTime);
+}

--- a/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertSeatJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/concert/port/jpa/ConcertSeatJpaRepository.java
@@ -1,0 +1,28 @@
+package io.hhplus.concert.concert.port.jpa;
+
+import io.hhplus.concert.concert.domain.ConcertSeat;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ConcertSeatJpaRepository extends JpaRepository<ConcertSeat, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ConcertSeat c WHERE c.id = :id")
+    Optional<ConcertSeat> findByIdWithLock(Long id);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<ConcertSeat> findAllByIdIn(List<Long> ids);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<ConcertSeat> findAllByConcertScheduleId(Long concertScheduleId);
+    List<Long> findAllIdsByConcertScheduleId(Long concertScheduleId);
+    List<Long> findAllIdsByConcertScheduleIdIn(Collection<Long> concertScheduleIds);
+}

--- a/src/main/java/io/hhplus/concert/concert/port/jpa/ReservationJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/concert/port/jpa/ReservationJpaRepository.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.concert.port.jpa;
+
+import io.hhplus.concert.concert.domain.Reservation;
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r WHERE r.id = :id")
+    Optional<Reservation> findByIdWithLock(Long id);
+
+    @Query("SELECT r.concertSeatId FROM Reservation r WHERE r.concertSeatId in :concertSeatIds and r.status in :statuses")
+    List<Long> findAllConcertSeatIdsByConcertSeatIdInAndStatusIn(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r.concertSeatId FROM Reservation r WHERE r.concertSeatId in :concertSeatIds and r.status in :statuses")
+    List<Long> findAllConcertSeatIdsByConcertSeatIdInAndStatusInWithLock(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Reservation> findAllByStatusIn(Collection<ReservationStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Reservation> findAllByConcertSeatIdInAndStatusIn(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
+}

--- a/src/main/java/io/hhplus/concert/concert/usecase/ReservationSeatUseCase.java
+++ b/src/main/java/io/hhplus/concert/concert/usecase/ReservationSeatUseCase.java
@@ -1,26 +1,94 @@
 package io.hhplus.concert.concert.usecase;
 
-import lombok.Data;
+import io.hhplus.concert.concert.domain.ConcertSeat;
+import io.hhplus.concert.concert.domain.Reservation;
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+import io.hhplus.concert.concert.port.ConcertPort;
+import io.hhplus.concert.concert.port.ConcertSchedulePort;
+import io.hhplus.concert.concert.port.ConcertSeatPort;
+import io.hhplus.concert.concert.port.ReservationPort;
+import io.hhplus.concert.concert.usecase.dto.ReservationResult;
+import io.hhplus.concert.payment.domain.Payment;
+import io.hhplus.concert.payment.domain.enm.PaymentStatus;
+import io.hhplus.concert.payment.port.PaymentPort;
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.port.TokenPort;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+@AllArgsConstructor
 @Service
 public class ReservationSeatUseCase {
 
-    @Data
-    public static class Input {
-        private Long userId;
-        private String token;
-    }
-    public record Output(
-            Long reservationId,
-            Long concertScheduleId,
-            Integer seatNumber,
-            String reservationStatus,
-            Long paymentId,
-            String paymentStatus
-    ) {}
+    private final ConcertPort concertPort;
+    private final ConcertSchedulePort concertSchedulePort;
+    private final ConcertSeatPort concertSeatPort;
+    private final ReservationPort reservationPort;
+    private final PaymentPort paymentPort;
+    private final TokenPort tokenPort;
 
+    public record Input(
+            String keyUuid,
+            Long concertId,
+            Long concertScheduleId,
+            Long concertSeatId
+    ) { }
+
+    public record Output(
+            ReservationResult reservationResult
+    ) { }
+
+    @Transactional
     public Output execute(Input input) {
-        return null;
+
+        Token token = tokenPort.getByKey(input.keyUuid());
+
+        if (!concertPort.existsById(input.concertId())) {
+            throw new NoSuchElementException("Concert not found: " + input.concertId());
+        }
+
+        if (!concertSchedulePort.existsById(input.concertScheduleId())) {
+            throw new NoSuchElementException("Concert Schedule not found: " + input.concertScheduleId());
+        }
+
+        ConcertSeat seat = concertSeatPort.getWithLock(input.concertSeatId());
+
+        if (!seat.getIsActive()) {
+            throw new IllegalStateException("이미 예약된 좌석: " + seat.getId());
+        }
+
+        Payment payment = new Payment();
+        payment.setUserId(token.getUserId());
+        payment.setPrice(seat.getPrice());
+        payment.setStatus(PaymentStatus.PENDING);
+        payment.setDueAt(LocalDateTime.now().plusMinutes(5L));
+        payment = paymentPort.save(payment);
+
+        Reservation reservation = new Reservation();
+        reservation.setUserId(token.getUserId());
+        reservation.setConcertSeatId(input.concertSeatId());
+        reservation.setStatus(ReservationStatus.PENDING);
+        reservation.setPaymentId(payment.getId());
+        reservation = reservationPort.save(reservation);
+
+        seat.setIsActive(false);
+        seat = concertSeatPort.save(seat);
+
+        return new Output(
+                new ReservationResult(
+                        reservation.getId(),
+                        reservation.getUserId(),
+                        input.concertId(),
+                        input.concertScheduleId(),
+                        reservation.getConcertSeatId(),
+                        reservation.getStatus(),
+                        seat.getSeatNumber(),
+                        payment.getPaymentKey()
+                )
+        );
     }
 }

--- a/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertResult.java
+++ b/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertResult.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.concert.usecase.dto;
+
+public record ConcertResult(
+        Long concertId,
+        String title,
+        String cast
+) {
+}

--- a/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertScheduleResult.java
+++ b/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertScheduleResult.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.concert.usecase.dto;
+
+import java.time.LocalDateTime;
+
+public record ConcertScheduleResult(
+        Long concertId,
+        Long concertScheduleId,
+        LocalDateTime scheduledAt
+) {
+}

--- a/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertSeatResult.java
+++ b/src/main/java/io/hhplus/concert/concert/usecase/dto/ConcertSeatResult.java
@@ -1,0 +1,14 @@
+package io.hhplus.concert.concert.usecase.dto;
+
+import java.math.BigDecimal;
+
+public record ConcertSeatResult(
+        Long concertId,
+        Long concertScheduleId,
+        Long concertSeatId,
+        String label,
+        Integer seatNumber,
+        Boolean isActive,
+        BigDecimal price
+) {
+}

--- a/src/main/java/io/hhplus/concert/concert/usecase/dto/ReservationResult.java
+++ b/src/main/java/io/hhplus/concert/concert/usecase/dto/ReservationResult.java
@@ -1,0 +1,15 @@
+package io.hhplus.concert.concert.usecase.dto;
+
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+
+public record ReservationResult(
+        Long reservationId,
+        Long userId,
+        Long concertId,
+        Long concertScheduleId,
+        Long concertSeatId,
+        ReservationStatus status,
+        Integer seatNumber,
+        String paymentKey
+) {
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/Payment.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/Payment.java
@@ -1,0 +1,43 @@
+package io.hhplus.concert.payment.domain;
+
+import io.hhplus.concert.payment.domain.enm.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "user_id")
+        }
+)
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String paymentKey = UUID.randomUUID().toString();
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime dueAt;
+
+    @Column
+    private LocalDateTime paidAt;
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/PaymentTransaction.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/PaymentTransaction.java
@@ -1,0 +1,41 @@
+package io.hhplus.concert.payment.domain;
+
+import io.hhplus.concert.payment.domain.enm.PaymentMethod;
+import io.hhplus.concert.payment.domain.enm.PaymentTransactionStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+public class PaymentTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentMethod method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentTransactionStatus status;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentMethod.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentMethod.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.payment.domain.enm;
+
+public enum PaymentMethod {
+    CASH, POINT
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentStatus.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.payment.domain.enm;
+
+public enum PaymentStatus {
+    PENDING, PAID, REFUNDED, CANCELLED
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentTransactionStatus.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/enm/PaymentTransactionStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.payment.domain.enm;
+
+public enum PaymentTransactionStatus {
+    PURCHASE, REFUND
+}

--- a/src/main/java/io/hhplus/concert/payment/domain/enm/PgResultType.java
+++ b/src/main/java/io/hhplus/concert/payment/domain/enm/PgResultType.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.payment.domain.enm;
+
+public enum PgResultType {
+    OK,
+    INVALID,
+    ALREADY_PURCHASED,
+    REJECTED_PAYMENT,
+    EXCEED_REFUNDABLE_DUE,
+    REJECTED_REFUND,
+}

--- a/src/main/java/io/hhplus/concert/payment/port/PaymentPort.java
+++ b/src/main/java/io/hhplus/concert/payment/port/PaymentPort.java
@@ -1,0 +1,54 @@
+package io.hhplus.concert.payment.port;
+
+import io.hhplus.concert.payment.domain.Payment;
+import io.hhplus.concert.payment.port.jpa.PaymentJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class PaymentPort {
+
+    private final PaymentJpaRepository jpaRepository;
+
+    public Payment get(Long id) {
+        return jpaRepository.findById(id).orElseThrow();
+    }
+
+    public Payment getByPaymentKey(String paymentKey) {
+        return jpaRepository.findByPaymentKey(paymentKey).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 결제키: paymentKey = " + paymentKey));
+    }
+
+    public Payment getWithLock(Long id) {
+        return jpaRepository.findByIdWithLock(id).orElseThrow();
+    }
+
+    public Payment getByPaymentKeyWithLock(String paymentKey) {
+        return jpaRepository.findByPaymentKeyWithLock(paymentKey).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 결제키: paymentKey = " + paymentKey));
+    }
+
+    public Payment save(Payment payment) {
+        return jpaRepository.save(payment);
+    }
+
+    public List<Payment> saveAll(List<Payment> payments) {
+        return jpaRepository.saveAll(payments);
+    }
+
+    public void delete(Payment payment) {
+        jpaRepository.delete(payment);
+    }
+
+    public List<Payment> getExpiredAllByIdsWithLock(List<Long> ids) {
+        return jpaRepository.findAllByIdInAndDueAtLessThan(ids, LocalDateTime.now());
+    }
+
+    public List<Payment> getAvailableAllByIdsWithLock(List<Long> ids) {
+        return jpaRepository.findAllByIdInAndDueAtGreaterThanEqual(ids, LocalDateTime.now());
+    }
+}

--- a/src/main/java/io/hhplus/concert/payment/port/jpa/PaymentJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/payment/port/jpa/PaymentJpaRepository.java
@@ -1,0 +1,33 @@
+package io.hhplus.concert.payment.port.jpa;
+
+import io.hhplus.concert.payment.domain.Payment;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByPaymentKey(String paymentKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.id = :id")
+    Optional<Payment> findByIdWithLock(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.paymentKey = :paymentKey")
+    Optional<Payment> findByPaymentKeyWithLock(String paymentKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Payment> findAllByIdInAndDueAtLessThan(Collection<Long> ids, LocalDateTime baseDateTime);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Payment> findAllByIdInAndDueAtGreaterThanEqual(Collection<Long> ids, LocalDateTime baseDateTime);
+}

--- a/src/main/java/io/hhplus/concert/payment/port/jpa/PaymentTransactionJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/payment/port/jpa/PaymentTransactionJpaRepository.java
@@ -1,0 +1,20 @@
+package io.hhplus.concert.payment.port.jpa;
+
+import io.hhplus.concert.payment.domain.PaymentTransaction;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PaymentTransactionJpaRepository extends JpaRepository<PaymentTransaction, Long> {
+
+    Optional<PaymentTransaction> findByPaymentId(Long paymentId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM PaymentTransaction p WHERE p.paymentId = :paymentId")
+    Optional<PaymentTransaction> findByPaymentIdWithLock(Long paymentId);
+}

--- a/src/main/java/io/hhplus/concert/payment/usecase/dto/PendingPointChargeResult.java
+++ b/src/main/java/io/hhplus/concert/payment/usecase/dto/PendingPointChargeResult.java
@@ -1,0 +1,6 @@
+package io.hhplus.concert.payment.usecase.dto;
+
+public record PendingPointChargeResult(
+        String paymentKey
+) {
+}

--- a/src/main/java/io/hhplus/concert/payment/usecase/dto/PointChangeResult.java
+++ b/src/main/java/io/hhplus/concert/payment/usecase/dto/PointChangeResult.java
@@ -1,0 +1,11 @@
+package io.hhplus.concert.payment.usecase.dto;
+
+import io.hhplus.concert.user.domain.enm.PointTransactionType;
+
+public record PointChangeResult(
+        Long userId,
+        Integer remains,
+        PointTransactionType transactionType,
+        Integer changed
+) {
+}

--- a/src/main/java/io/hhplus/concert/payment/usecase/dto/PurchaseResult.java
+++ b/src/main/java/io/hhplus/concert/payment/usecase/dto/PurchaseResult.java
@@ -1,0 +1,16 @@
+package io.hhplus.concert.payment.usecase.dto;
+
+import io.hhplus.concert.payment.domain.enm.PaymentStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PurchaseResult(
+        Long paymentId,
+        Long userId,
+        BigDecimal amount,
+        PaymentStatus paymentStatus,
+        LocalDateTime dueAt,
+        LocalDateTime paidAt
+) {
+}

--- a/src/main/java/io/hhplus/concert/user/domain/PointTransaction.java
+++ b/src/main/java/io/hhplus/concert/user/domain/PointTransaction.java
@@ -1,0 +1,51 @@
+package io.hhplus.concert.user.domain;
+
+import io.hhplus.concert.user.domain.enm.PointTransactionStatus;
+import io.hhplus.concert.user.domain.enm.PointTransactionType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "user_point_id"),
+                @Index(columnList = "payment_id"),
+        }
+)
+public class PointTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userPointId;
+
+    @Column
+    private Integer remains;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PointTransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PointTransactionStatus status;
+
+    @Column
+    private Long paymentId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/io/hhplus/concert/user/domain/ServiceEntry.java
+++ b/src/main/java/io/hhplus/concert/user/domain/ServiceEntry.java
@@ -1,0 +1,32 @@
+package io.hhplus.concert.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "entry_at"),
+                @Index(columnList = "enrolled_at")
+        }
+)
+public class ServiceEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long tokenId;
+
+    @Column(nullable = false)
+    private LocalDateTime entryAt;
+
+    @Column
+    private LocalDateTime enrolledAt;
+}

--- a/src/main/java/io/hhplus/concert/user/domain/Token.java
+++ b/src/main/java/io/hhplus/concert/user/domain/Token.java
@@ -1,0 +1,35 @@
+package io.hhplus.concert.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        indexes = {
+                @Index(columnList = "user_id")
+        }
+)
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String keyUuid = UUID.randomUUID().toString();
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/io/hhplus/concert/user/domain/User.java
+++ b/src/main/java/io/hhplus/concert/user/domain/User.java
@@ -1,0 +1,27 @@
+package io.hhplus.concert.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/io/hhplus/concert/user/domain/UserPoint.java
+++ b/src/main/java/io/hhplus/concert/user/domain/UserPoint.java
@@ -1,0 +1,21 @@
+package io.hhplus.concert.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class UserPoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer remains = 0;
+}

--- a/src/main/java/io/hhplus/concert/user/domain/enm/PointTransactionStatus.java
+++ b/src/main/java/io/hhplus/concert/user/domain/enm/PointTransactionStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.user.domain.enm;
+
+public enum PointTransactionStatus {
+    PENDING, COMPLETE, CANCELLED
+}

--- a/src/main/java/io/hhplus/concert/user/domain/enm/PointTransactionType.java
+++ b/src/main/java/io/hhplus/concert/user/domain/enm/PointTransactionType.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.user.domain.enm;
+
+public enum PointTransactionType {
+    CHARGE, USED
+}

--- a/src/main/java/io/hhplus/concert/user/port/PointTransactionPort.java
+++ b/src/main/java/io/hhplus/concert/user/port/PointTransactionPort.java
@@ -1,0 +1,37 @@
+package io.hhplus.concert.user.port;
+
+import io.hhplus.concert.user.domain.PointTransaction;
+import io.hhplus.concert.user.domain.enm.PointTransactionStatus;
+import io.hhplus.concert.user.port.jpa.PointTransactionJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class PointTransactionPort {
+
+    private final PointTransactionJpaRepository jpaRepository;
+
+    public PointTransaction getByPaymentId(Long paymentId) {
+        return jpaRepository.findByPaymentId(paymentId).orElseThrow();
+    }
+
+    public List<PointTransaction> getAllByStatusesWithLock(Collection<PointTransactionStatus> statuses) {
+        return jpaRepository.findAllByStatusIn(statuses);
+    }
+
+    public PointTransaction save(PointTransaction pointTransaction) {
+        return jpaRepository.save(pointTransaction);
+    }
+
+    public List<PointTransaction> saveAll(Iterable<PointTransaction> pointTransactions) {
+        return jpaRepository.saveAll(pointTransactions);
+    }
+
+    public void delete(PointTransaction pointTransaction) {
+        jpaRepository.delete(pointTransaction);
+    }
+}

--- a/src/main/java/io/hhplus/concert/user/port/TokenPort.java
+++ b/src/main/java/io/hhplus/concert/user/port/TokenPort.java
@@ -1,0 +1,44 @@
+package io.hhplus.concert.user.port;
+
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.port.jpa.TokenJpaRepository;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@Repository
+public class TokenPort {
+
+    private final TokenJpaRepository jpaRepository;
+
+    public Token getByKey(@NotNull String keyUuid) {
+        return jpaRepository.findByKeyUuid(keyUuid).orElseThrow(
+                () -> new BadCredentialsException("존재하지 않는 토큰: keyUuid = " + keyUuid));
+    }
+
+    public Token getByKeyWithLock(@NotNull String keyUuid) {
+        return jpaRepository.findByKeyUuidWithLock(keyUuid).orElseThrow(
+                () -> new BadCredentialsException("존재하지 않는 토큰: key = " + keyUuid));
+    }
+
+    public Boolean existsByUserId(@NotNull Long userId) {
+        return jpaRepository.existsByUserId(userId);
+    }
+
+    public Token save(@NotNull Token token) {
+        return jpaRepository.save(token);
+    }
+
+    public List<Long> findAllIdsExpiredWithLock() {
+        return jpaRepository.findAllIdsByExpiresAtLessThan(LocalDateTime.now());
+    }
+
+    public void deleteAll(Iterable<Token> tokens) {
+        jpaRepository.deleteAll(tokens);
+    }
+}

--- a/src/main/java/io/hhplus/concert/user/port/UserPointPort.java
+++ b/src/main/java/io/hhplus/concert/user/port/UserPointPort.java
@@ -1,0 +1,25 @@
+package io.hhplus.concert.user.port;
+
+import io.hhplus.concert.user.domain.UserPoint;
+import io.hhplus.concert.user.port.jpa.UserPointJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@AllArgsConstructor
+@Repository
+public class UserPointPort {
+
+    private final UserPointJpaRepository jpaRepository;
+
+    public UserPoint getByUserId(Long userId) {
+        return jpaRepository.findByUserId(userId).orElseThrow();
+    }
+
+    public UserPoint getByUserIdWithLock(Long userId) {
+        return jpaRepository.findByUserIdWithLock(userId).orElseThrow();
+    }
+
+    public UserPoint save(UserPoint userPoint) {
+        return jpaRepository.save(userPoint);
+    }
+}

--- a/src/main/java/io/hhplus/concert/user/port/UserPort.java
+++ b/src/main/java/io/hhplus/concert/user/port/UserPort.java
@@ -1,0 +1,26 @@
+package io.hhplus.concert.user.port;
+
+import io.hhplus.concert.user.domain.User;
+import io.hhplus.concert.user.port.jpa.UserJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+@AllArgsConstructor
+@Repository
+public class UserPort {
+
+    private final UserJpaRepository jpaRepository;
+
+    public Boolean isExists(Long userId) {
+        return jpaRepository.existsById(userId);
+    }
+
+    public User save(User user) {
+        return jpaRepository.save(user);
+    }
+
+    public User get(Long userId) {
+        return jpaRepository.findById(userId).orElseThrow();
+    }
+}

--- a/src/main/java/io/hhplus/concert/user/port/UserPort.java
+++ b/src/main/java/io/hhplus/concert/user/port/UserPort.java
@@ -3,7 +3,6 @@ package io.hhplus.concert.user.port;
 import io.hhplus.concert.user.domain.User;
 import io.hhplus.concert.user.port.jpa.UserJpaRepository;
 import lombok.AllArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
 @AllArgsConstructor

--- a/src/main/java/io/hhplus/concert/user/port/jpa/PointTransactionJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/user/port/jpa/PointTransactionJpaRepository.java
@@ -1,0 +1,22 @@
+package io.hhplus.concert.user.port.jpa;
+
+import io.hhplus.concert.payment.domain.enm.PaymentTransactionStatus;
+import io.hhplus.concert.user.domain.PointTransaction;
+import io.hhplus.concert.user.domain.enm.PointTransactionStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PointTransactionJpaRepository extends JpaRepository<PointTransaction, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<PointTransaction> findAllByStatusIn(Collection<PointTransactionStatus> statuses);
+
+    Optional<PointTransaction> findByPaymentId(Long paymentId);
+}

--- a/src/main/java/io/hhplus/concert/user/port/jpa/ServiceEntryJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/user/port/jpa/ServiceEntryJpaRepository.java
@@ -1,0 +1,51 @@
+package io.hhplus.concert.user.port.jpa;
+
+import io.hhplus.concert.user.domain.ServiceEntry;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ServiceEntryJpaRepository extends JpaRepository<ServiceEntry, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e.tokenId FROM ServiceEntry e WHERE e.enrolledAt < :baseDateTime")
+    List<Long> findAllTokenIdByEnrolledAtLessThan(LocalDateTime baseDateTime);
+
+    void deleteByTokenId(Long tokenId);
+    void deleteAllByTokenIdIn(Collection<Long> tokenIds);
+
+    Optional<ServiceEntry> findByTokenId(Long tokenId);
+    Boolean existsByTokenId(Long tokenId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e.tokenId FROM ServiceEntry e WHERE e.enrolledAt IS NULL ORDER BY e.entryAt ASC")
+    List<Long> findAllTokenIdByOrderByEntryAtTopWithLock(Pageable pageable);
+
+    @Query(value = """
+        SELECT row_num FROM (
+            SELECT token_id, ROW_NUMBER() OVER (ORDER BY entry_at) AS row_num
+            FROM service_entry
+            WHERE enrolled_at IS NULL
+        ) AS ranked
+        WHERE ranked.token_id = :tokenId
+    """, nativeQuery = true)
+    Long getEntryRankByTokenId(@Param("tokenId") Long tokenId);
+
+    @Modifying
+    @Query("UPDATE ServiceEntry e SET e.enrolledAt = :enrolledAt WHERE e.tokenId IN :tokenIds")
+    Integer updateAllByTokenIdIn(
+            Collection<Long> tokenIds,
+            LocalDateTime enrolledAt
+    );
+}

--- a/src/main/java/io/hhplus/concert/user/port/jpa/TokenJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/user/port/jpa/TokenJpaRepository.java
@@ -1,0 +1,30 @@
+package io.hhplus.concert.user.port.jpa;
+
+import io.hhplus.concert.user.domain.Token;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TokenJpaRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findByKeyUuid(String key);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Token t WHERE t.keyUuid = :keyUuid")
+    Optional<Token> findByKeyUuidWithLock(String keyUuid);
+
+    Boolean existsByUserId(Long userId);
+
+    Optional<Token> findByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t.id FROM Token t WHERE t.expiresAt < :baseDateTime")
+    List<Long> findAllIdsByExpiresAtLessThan(LocalDateTime baseDateTime);
+}

--- a/src/main/java/io/hhplus/concert/user/port/jpa/UserJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/user/port/jpa/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package io.hhplus.concert.user.port.jpa;
+
+import io.hhplus.concert.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/io/hhplus/concert/user/port/jpa/UserPointJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/user/port/jpa/UserPointJpaRepository.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.user.port.jpa;
+
+import io.hhplus.concert.user.domain.UserPoint;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface UserPointJpaRepository extends JpaRepository<UserPoint, Long> {
+
+    Optional<UserPoint> findByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM UserPoint p WHERE p.userId = :userId")
+    Optional<UserPoint> findByUserIdWithLock(Long userId);
+}

--- a/src/main/java/io/hhplus/concert/user/usecase/CheckTokenEnrolledUseCase.java
+++ b/src/main/java/io/hhplus/concert/user/usecase/CheckTokenEnrolledUseCase.java
@@ -1,0 +1,65 @@
+package io.hhplus.concert.user.usecase;
+
+import io.hhplus.concert.user.domain.ServiceEntry;
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.port.ServiceEntryPort;
+import io.hhplus.concert.user.port.TokenPort;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Service
+public class CheckTokenEnrolledUseCase {
+
+    private final ServiceEntryPort serviceEntryPort;
+    private final TokenPort tokenPort;
+
+    public record Input(
+            String keyUuid
+    ) { }
+
+    public record Output(
+            Boolean isAuthenticated,
+            Long rank
+    ) { }
+
+    @Transactional
+    public Output execute(Input input) {
+        // 토큰 조회 (없을 경우 BadCredentialsException -> 401)
+        Token token = tokenPort.getByKey(input.keyUuid());
+
+        if (token.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BadCredentialsException("Token Expired");
+        }
+
+        ServiceEntry serviceEntry;
+        if (serviceEntryPort.exists(token.getId())) {
+            // 등록된 토큰인 경우 불러오기
+            serviceEntry = serviceEntryPort.getByTokenId(token.getId());
+        } else {
+            // 미등록 토큰인 경우 등록
+            serviceEntry = new ServiceEntry();
+            serviceEntry.setTokenId(token.getId());
+            serviceEntry.setEntryAt(LocalDateTime.now());
+            serviceEntry = serviceEntryPort.save(serviceEntry);
+        }
+
+        boolean isAuthenticated = true;
+        Long rank = null;
+
+        if (serviceEntry.getEnrolledAt() == null) {
+            // 미진입 상태 -> 403
+            isAuthenticated = false;
+            rank = serviceEntryPort.getEntryRankByTokenId(token.getId());
+        }
+
+        return new Output(
+                isAuthenticated,
+                rank
+        );
+    }
+}

--- a/src/main/java/io/hhplus/concert/user/usecase/IssueTokenUseCase.java
+++ b/src/main/java/io/hhplus/concert/user/usecase/IssueTokenUseCase.java
@@ -1,17 +1,59 @@
 package io.hhplus.concert.user.usecase;
 
-import lombok.Data;
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.domain.User;
+import io.hhplus.concert.user.domain.UserPoint;
+import io.hhplus.concert.user.port.TokenPort;
+import io.hhplus.concert.user.port.UserPointPort;
+import io.hhplus.concert.user.port.UserPort;
+import io.hhplus.concert.user.usecase.dto.TokenResult;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
 @Service
 public class IssueTokenUseCase {
 
-    @Data
-    public static class Input {
-    }
-    public record Output(String token) {}
+    private final TokenPort tokenPort;
+    private final UserPort userPort;
+    private final UserPointPort userPointPort;
+    private final PasswordEncoder passwordEncoder;
 
+    public record Input(
+            Long userId
+    ) { }
+
+    public record Output(
+            TokenResult tokenResult
+    ) { }
+
+    @Transactional
     public Output execute(Input input) {
-        return null;
+        Long userId = input.userId();
+
+        if (!userPort.isExists(userId)) {
+            User user = new User();
+            user.setId(userId);
+            user.setUsername("유저 " + userId);
+            user.setPassword(passwordEncoder.encode("passFor" + userId));
+            user.setCreatedAt(LocalDateTime.now());
+            userPort.save(user);
+
+            UserPoint userPoint = new UserPoint();
+            userPoint.setUserId(userId);
+            userPointPort.save(userPoint);
+        }
+
+        Token token = new Token();
+        token.setUserId(userId);
+        token.setCreatedAt(LocalDateTime.now());
+        token.setExpiresAt(token.getCreatedAt().plusDays(1L));
+        token = tokenPort.save(token);
+
+        return new Output(new TokenResult(token.getKeyUuid()));
     }
 }

--- a/src/main/java/io/hhplus/concert/user/usecase/dto/ChargePointResult.java
+++ b/src/main/java/io/hhplus/concert/user/usecase/dto/ChargePointResult.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.user.usecase.dto;
+
+import jakarta.validation.constraints.Min;
+
+import java.math.BigDecimal;
+
+public record ChargePointResult(
+        @Min(1) BigDecimal chargeAmount
+) {
+}

--- a/src/main/java/io/hhplus/concert/user/usecase/dto/TokenResult.java
+++ b/src/main/java/io/hhplus/concert/user/usecase/dto/TokenResult.java
@@ -1,0 +1,6 @@
+package io.hhplus.concert.user.usecase.dto;
+
+public record TokenResult(
+        String keyUuid
+) {
+}

--- a/src/main/java/io/hhplus/concert/user/usecase/dto/UserPointResult.java
+++ b/src/main/java/io/hhplus/concert/user/usecase/dto/UserPointResult.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.user.usecase.dto;
+
+public record UserPointResult(
+        Long userId,
+        Integer remains
+) {
+}

--- a/src/test/java/io/hhplus/concert/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
@@ -1,0 +1,211 @@
+package io.hhplus.concert.unit.concert.usecase;
+
+import io.hhplus.concert.concert.domain.ConcertSeat;
+import io.hhplus.concert.concert.domain.Reservation;
+import io.hhplus.concert.concert.domain.enm.ReservationStatus;
+import io.hhplus.concert.concert.port.ConcertPort;
+import io.hhplus.concert.concert.port.ConcertSchedulePort;
+import io.hhplus.concert.concert.port.ConcertSeatPort;
+import io.hhplus.concert.concert.port.ReservationPort;
+import io.hhplus.concert.concert.usecase.ReservationSeatUseCase;
+import io.hhplus.concert.concert.usecase.SearchAvailableSeatsUseCase;
+import io.hhplus.concert.payment.domain.Payment;
+import io.hhplus.concert.payment.port.PaymentPort;
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.port.TokenPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationSeatUseCaseUnitTest {
+
+    @Mock
+    private ConcertPort concertPort;
+
+    @Mock
+    private ConcertSchedulePort concertSchedulePort;
+
+    @Mock
+    private ConcertSeatPort concertSeatPort;
+
+    @Mock
+    private ReservationPort reservationPort;
+
+    @Mock
+    private PaymentPort paymentPort;
+
+    @Mock
+    private TokenPort tokenPort;
+
+    @InjectMocks
+    private ReservationSeatUseCase reservationSeatUseCase;
+
+    private String keyUuid;
+
+    private Token token;
+
+    private ConcertSeat concertSeat;
+
+    @BeforeEach
+    public void setUp() {
+        keyUuid = UUID.randomUUID().toString();
+        token = new Token();
+        token.setId(3840L);
+        token.setKeyUuid(keyUuid);
+        token.setUserId(64L);
+        token.setCreatedAt(LocalDateTime.now());
+
+        concertSeat = new ConcertSeat();
+        concertSeat.setId(3L);
+        concertSeat.setConcertScheduleId(2L);
+        concertSeat.setLabel("일반석");
+        concertSeat.setPrice(BigDecimal.valueOf(12000));
+        concertSeat.setSeatNumber(53);
+        concertSeat.setIsActive(true);
+
+        lenient().when(tokenPort.getByKey(eq(keyUuid))).thenReturn(token);
+        lenient().when(concertPort.existsById(any(Long.class))).thenReturn(true);
+        lenient().when(concertSchedulePort.existsById(any(Long.class))).thenReturn(true);
+        lenient().when(concertSeatPort.getWithLock(any(Long.class))).thenReturn(concertSeat);
+        lenient().when(concertSeatPort.save(any(ConcertSeat.class))).thenReturn(concertSeat);
+
+        lenient().when(paymentPort.save(any(Payment.class))).then(r -> {
+            Payment result = r.getArgument(0);
+            result.setId(2560L);
+            return result;
+        });
+
+        lenient().when(reservationPort.save(any(Reservation.class))).then(r -> {
+            Reservation result = r.getArgument(0);
+            result.setId(1280L);
+            return result;
+        });
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하지 않으면 예외를 발생한다")
+    public void tokenNotFound() {
+        String unknownToken = UUID.randomUUID().toString();
+        // 본래 Security Config에서 Authorization 인증을 통해 이미 검증되므로 발생하지 않는 케이스임
+        BadCredentialsException e = new BadCredentialsException("존재하지 않는 토큰: keyUuid = " + unknownToken);
+        when(tokenPort.getByKey(eq(unknownToken))).thenThrow(e);
+
+        BadCredentialsException ex = assertThrows(
+                BadCredentialsException.class,
+                () -> reservationSeatUseCase.execute(
+                        new ReservationSeatUseCase.Input(
+                                unknownToken,
+                                1L,
+                                2L,
+                                3L
+                        )
+                ));
+
+        assertEquals(e.getMessage(), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("콘서트가 없으면 예외가 발생한다")
+    public void noConcert() {
+        when(concertPort.existsById(any(Long.class))).thenReturn(false);
+
+        NoSuchElementException e = assertThrows(
+                NoSuchElementException.class, () -> reservationSeatUseCase.execute(
+                        new ReservationSeatUseCase.Input(
+                                keyUuid,
+                                1L,
+                                2L,
+                                3L
+                        )
+                ));
+
+        assertEquals("Concert not found: " + 1L, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("스케줄이 없으면 예외가 발생한다")
+    public void noSchedule() {
+        when(concertSchedulePort.existsById(any(Long.class))).thenReturn(false);
+
+        NoSuchElementException e = assertThrows(
+                NoSuchElementException.class, () -> reservationSeatUseCase.execute(
+                        new ReservationSeatUseCase.Input(
+                                keyUuid,
+                                1L,
+                                2L,
+                                3L
+                        )
+                ));
+
+        assertEquals("Concert Schedule not found: " + 2L, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("좌석이 없으면 예외가 발생한다")
+    public void noSeat() {
+        when(concertSeatPort.getWithLock(any(Long.class))).thenThrow(new NoSuchElementException("No value present"));
+
+        NoSuchElementException e = assertThrows(
+                NoSuchElementException.class, () -> reservationSeatUseCase.execute(
+                        new ReservationSeatUseCase.Input(
+                                keyUuid,
+                                1L,
+                                2L,
+                                3L
+                        )
+                ));
+
+        assertEquals("No value present", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("좌석이 비활성화 상태면 예외가 발생한다")
+    public void noActivatedSeat() {
+        concertSeat.setIsActive(false);
+
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class, () -> reservationSeatUseCase.execute(
+                        new ReservationSeatUseCase.Input(
+                                keyUuid,
+                                1L,
+                                2L,
+                                3L
+                        )
+                ));
+
+        assertEquals("이미 예약된 좌석: " + concertSeat.getId(), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("좌석을 임시로 예약한다")
+    public void tempReserveSeat() {
+        ReservationSeatUseCase.Output output = reservationSeatUseCase.execute(
+                new ReservationSeatUseCase.Input(
+                        keyUuid,
+                        1L,
+                        2L,
+                        3L
+                )
+        );
+
+        assertEquals(ReservationStatus.PENDING, output.reservationResult().status());
+    }
+}

--- a/src/test/java/io/hhplus/concert/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
@@ -8,7 +8,6 @@ import io.hhplus.concert.concert.port.ConcertSchedulePort;
 import io.hhplus.concert.concert.port.ConcertSeatPort;
 import io.hhplus.concert.concert.port.ReservationPort;
 import io.hhplus.concert.concert.usecase.ReservationSeatUseCase;
-import io.hhplus.concert.concert.usecase.SearchAvailableSeatsUseCase;
 import io.hhplus.concert.payment.domain.Payment;
 import io.hhplus.concert.payment.port.PaymentPort;
 import io.hhplus.concert.user.domain.Token;

--- a/src/test/java/io/hhplus/concert/unit/user/usecase/CheckTokenEnrolledUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/unit/user/usecase/CheckTokenEnrolledUseCaseUnitTest.java
@@ -1,0 +1,126 @@
+package io.hhplus.concert.unit.user.usecase;
+
+import io.hhplus.concert.user.domain.ServiceEntry;
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.port.ServiceEntryPort;
+import io.hhplus.concert.user.port.TokenPort;
+import io.hhplus.concert.user.usecase.CheckTokenEnrolledUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CheckTokenEnrolledUseCaseUnitTest {
+
+    @Mock
+    private ServiceEntryPort serviceEntryPort;
+
+    @Mock
+    private TokenPort tokenPort;
+
+    @InjectMocks
+    private CheckTokenEnrolledUseCase checkTokenEnrolledUseCase;
+
+    private Token token;
+
+    @BeforeEach
+    public void setUp() {
+        token = new Token();
+        token.setId(1L);
+        token.setUserId(11L);
+        token.setCreatedAt(LocalDateTime.now());
+        token.setExpiresAt(LocalDateTime.now().plusDays(1));
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하지 않으면 오류가 발생한다")
+    public void tokenNotFound() {
+        Throwable e = new BadCredentialsException("존재하지 않는 토큰: keyUuid = " + token.getKeyUuid());
+        when(tokenPort.getByKey(eq(token.getKeyUuid()))).thenThrow(e);
+
+        BadCredentialsException r = assertThrows(
+                BadCredentialsException.class,
+                () -> checkTokenEnrolledUseCase.execute(
+                        new CheckTokenEnrolledUseCase.Input(token.getKeyUuid())
+                )
+        );
+        assertEquals(e.getMessage(), r.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하면서 등록된 상태가 아니면 대기열에 등록한다")
+    public void notEntriesToken() {
+        when(tokenPort.getByKey(eq(token.getKeyUuid()))).then(r -> token);
+        when(serviceEntryPort.exists(eq(token.getId()))).thenReturn(false);
+        when(serviceEntryPort.save(any(ServiceEntry.class))).then(r -> {
+            ServiceEntry serviceEntry = r.getArgument(0);
+            serviceEntry.setId(111L);
+            return serviceEntry;
+        });
+        when(serviceEntryPort.getEntryRankByTokenId(eq(token.getId()))).thenReturn(100L);
+
+        CheckTokenEnrolledUseCase.Output output = checkTokenEnrolledUseCase.execute(
+                new CheckTokenEnrolledUseCase.Input(token.getKeyUuid())
+        );
+
+        assertEquals(false, output.isAuthenticated());
+        assertEquals(100L, output.rank());
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하면서 등록된 상태이고 미진입 상태면 현재 상태와 순서를 반환한다")
+    public void entriesTokenAndWait() {
+        when(tokenPort.getByKey(eq(token.getKeyUuid()))).then(r -> token);
+        when(serviceEntryPort.exists(eq(token.getId()))).thenReturn(true);
+        when(serviceEntryPort.getByTokenId(eq(token.getId()))).then(r -> {
+            ServiceEntry serviceEntry = new ServiceEntry();
+            serviceEntry.setId(112L);
+            serviceEntry.setTokenId(token.getId());
+            serviceEntry.setEntryAt(LocalDateTime.now().minusMinutes(2));
+            serviceEntry.setEnrolledAt(null);
+            return serviceEntry;
+        });
+        when(serviceEntryPort.getEntryRankByTokenId(eq(token.getId()))).thenReturn(20L);
+
+        CheckTokenEnrolledUseCase.Output output = checkTokenEnrolledUseCase.execute(
+                new CheckTokenEnrolledUseCase.Input(token.getKeyUuid())
+        );
+
+        assertEquals(false, output.isAuthenticated());
+        assertEquals(20L, output.rank());
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하면서 등록된 상태이고 진입 상태면 현재 상태만 반환한다")
+    public void entriesTokenAndEnrolled() {
+        when(tokenPort.getByKey(eq(token.getKeyUuid()))).then(r -> token);
+        when(serviceEntryPort.exists(eq(token.getId()))).thenReturn(true);
+        when(serviceEntryPort.getByTokenId(eq(token.getId()))).then(r -> {
+            ServiceEntry serviceEntry = new ServiceEntry();
+            serviceEntry.setId(113L);
+            serviceEntry.setTokenId(token.getId());
+            serviceEntry.setEntryAt(LocalDateTime.now().minusMinutes(2));
+            serviceEntry.setEnrolledAt(LocalDateTime.now().minusMinutes(1));
+            return serviceEntry;
+        });
+
+        CheckTokenEnrolledUseCase.Output output = checkTokenEnrolledUseCase.execute(
+                new CheckTokenEnrolledUseCase.Input(token.getKeyUuid())
+        );
+
+        assertEquals(true, output.isAuthenticated());
+        assertNull(output.rank());
+    }
+}

--- a/src/test/java/io/hhplus/concert/unit/user/usecase/IssueTokenUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/unit/user/usecase/IssueTokenUseCaseUnitTest.java
@@ -1,0 +1,106 @@
+package io.hhplus.concert.unit.user.usecase;
+
+import io.hhplus.concert.user.domain.Token;
+import io.hhplus.concert.user.domain.User;
+import io.hhplus.concert.user.domain.UserPoint;
+import io.hhplus.concert.user.port.TokenPort;
+import io.hhplus.concert.user.port.UserPointPort;
+import io.hhplus.concert.user.port.UserPort;
+import io.hhplus.concert.user.usecase.IssueTokenUseCase;
+import io.hhplus.concert.user.usecase.dto.TokenResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class IssueTokenUseCaseUnitTest {
+
+    @Mock
+    private TokenPort tokenPort;
+
+    @Mock
+    private UserPort userPort;
+
+    @Mock
+    private UserPointPort userPointPort;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private IssueTokenUseCase issueTokenUseCase;
+
+    private final List<User> userCreated = new ArrayList<>();
+    private final List<UserPoint> userPointCreated = new ArrayList<>();
+    private final List<Token> tokenCreated = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        lenient().when(passwordEncoder.encode(any(String.class))).thenReturn("< Encoded Password >");
+        lenient().when(userPort.save(any(User.class))).then(r -> {
+            userCreated.add(r.getArgument(0));
+            return r.getArgument(0);
+        });
+        lenient().when(userPointPort.save(any(UserPoint.class))).then(r -> {
+            userPointCreated.add(r.getArgument(0));
+            return r.getArgument(0);
+        });
+        when(tokenPort.save(any(Token.class))).then(r -> {
+            tokenCreated.add(r.getArgument(0));
+            return r.getArgument(0);
+        });
+    }
+
+    @AfterEach
+    public void tearDown() {
+        userCreated.clear();
+        userPointCreated.clear();
+        tokenCreated.clear();
+    }
+
+    @Test
+    @DisplayName("유저가 없을 때 유저와 유저 포인트를 생성하고 토큰을 발행한다")
+    public void noUser() {
+        when(userPort.isExists(any(Long.class))).thenReturn(false);
+
+        IssueTokenUseCase.Output output = issueTokenUseCase.execute(new IssueTokenUseCase.Input(
+                10L
+        ));
+        TokenResult result = output.tokenResult();
+
+        assertEquals(1, userCreated.size());
+        assertEquals(1, userPointCreated.size());
+        assertEquals(1, tokenCreated.size());
+        assertEquals(tokenCreated.get(0).getKeyUuid(), result.keyUuid());
+    }
+
+    @Test
+    @DisplayName("유저가 있다면 토큰만 발행한다")
+    public void existsUser() {
+        when(userPort.isExists(any(Long.class))).thenReturn(true);
+
+        IssueTokenUseCase.Output output = issueTokenUseCase.execute(new IssueTokenUseCase.Input(
+                10L
+        ));
+        TokenResult result = output.tokenResult();
+
+        assertEquals(0, userCreated.size());
+        assertEquals(0, userPointCreated.size());
+        assertEquals(1, tokenCreated.size());
+        assertEquals(tokenCreated.get(0).getKeyUuid(), result.keyUuid());
+    }
+}


### PR DESCRIPTION
### **`DEFAULT`**

- 각 시나리오별 하기 **비즈니스 로직** 개발 및 **단위 테스트** 작성
    - [x] 대기열 발급
    - [x] 대기순번 조회
    - [x] 좌석 예약 기능

- 특이사항
    - 대기순번 조회 기능을 사용자 토큰 인증 미들웨어에 통합했습니다.
        - [`CheckTokenEnrolledUseCase.java`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/pull/6/commits/1c07e44f439a7b3de49acd2f0c0013cff9440d15#diff-8d828f7729aa61fe8d6fe8ab1e6198a011d9e244f374cd8ad806883049e08760)
        - [`SecurityConfig.java`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/main/src/main/java/io/hhplus/concert/config/SecurityConfig.java)
        - [`AuthorizationHeaderFilter.java`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/main/src/main/java/io/hhplus/concert/config/filter/AuthorizationHeaderFilter.java)
    - 대기열 입장 및 서비스 이용에 필요한 UUID를 헤더의 Authorization에 포함하여 SpringSecurity에서 처리하도록 작업했습니다.
    - 토큰 발행 API 외 모든 API가 해당 미들웨어에 의해 서비스 이용 불가 상태일 경우 403 상태값과 함께 대기순번을 반환하게 됩니다.
    - (추가) 커밋 분리할 때 ServiceEntryPort 코드가 Default PR에 누락되어 Step7에 포함되어 있습니다. 다음 링크에서 확인하실 수 있습니다 [Code Link](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/main/src/main/java/io/hhplus/concert/user/port/ServiceEntryPort.java)