### PR TITLE
[STEP 12]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+    implementation("org.redisson:redisson-spring-boot-starter:3.23.4")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/io/hhplus/concert/app/concert/port/ConcertSeatPort.java
+++ b/src/main/java/io/hhplus/concert/app/concert/port/ConcertSeatPort.java
@@ -49,7 +49,15 @@ public class ConcertSeatPort {
         return jpaRepository.findAllByIdIn(ids);
     }
 
-    public List<ConcertSeat> getAllByConcertScheduleIdWithLock(Long concertScheduleId) {
+    public List<ConcertSeat> getAllByIds(List<Long> ids) {
+        return jpaRepository.findAllByIdInWithLock(ids);
+    }
+
+    public List<ConcertSeat> getAllByConcertScheduleId(Long concertScheduleId) {
         return jpaRepository.findAllByConcertScheduleId(concertScheduleId);
+    }
+
+    public List<ConcertSeat> getAllByConcertScheduleIdWithLock(Long concertScheduleId) {
+        return jpaRepository.findAllByConcertScheduleIdWithLock(concertScheduleId);
     }
 }

--- a/src/main/java/io/hhplus/concert/app/concert/port/ReservationPort.java
+++ b/src/main/java/io/hhplus/concert/app/concert/port/ReservationPort.java
@@ -34,8 +34,12 @@ public class ReservationPort {
         return jpaRepository.findAllConcertSeatIdsByConcertSeatIdInAndStatusInWithLock(concertSeatIds, statuses);
     }
 
-    public List<Reservation> getAllByStatusesWithLock(List<ReservationStatus> statuses) {
+    public List<Reservation> getAllByStatuses(List<ReservationStatus> statuses) {
         return jpaRepository.findAllByStatusIn(statuses);
+    }
+
+    public List<Reservation> getAllByStatusesWithLock(List<ReservationStatus> statuses) {
+        return jpaRepository.findAllByStatusInWithLock(statuses);
     }
 
     public List<Reservation> getAllByConcertSeatIdsAndStatusesWithLock(List<Long> concertSeatIds, List<ReservationStatus> statuses) {

--- a/src/main/java/io/hhplus/concert/app/concert/port/jpa/ConcertSeatJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/concert/port/jpa/ConcertSeatJpaRepository.java
@@ -16,8 +16,16 @@ public interface ConcertSeatJpaRepository extends JpaRepository<ConcertSeat, Lon
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM ConcertSeat c WHERE c.id = :id")
     Optional<ConcertSeat> findByIdWithLock(Long id);
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+
     List<ConcertSeat> findAllByIdIn(List<Long> ids);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ConcertSeat c WHERE c.id in :ids")
+    List<ConcertSeat> findAllByIdInWithLock(List<Long> ids);
+
     List<ConcertSeat> findAllByConcertScheduleId(Long concertScheduleId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ConcertSeat c WHERE c.concertScheduleId = :concertScheduleId")
+    List<ConcertSeat> findAllByConcertScheduleIdWithLock(Long concertScheduleId);
 }

--- a/src/main/java/io/hhplus/concert/app/concert/port/jpa/ReservationJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/concert/port/jpa/ReservationJpaRepository.java
@@ -19,16 +19,21 @@ public interface ReservationJpaRepository extends JpaRepository<Reservation, Lon
     @Query("SELECT r FROM Reservation r WHERE r.id = :id")
     Optional<Reservation> findByIdWithLock(Long id);
 
-    @Query("SELECT r.concertSeatId FROM Reservation r WHERE r.concertSeatId in :concertSeatIds and r.status in :statuses")
     List<Long> findAllConcertSeatIdsByConcertSeatIdInAndStatusIn(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r.concertSeatId FROM Reservation r WHERE r.concertSeatId in :concertSeatIds and r.status in :statuses")
     List<Long> findAllConcertSeatIdsByConcertSeatIdInAndStatusInWithLock(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<Reservation> findAllByStatusIn(Collection<ReservationStatus> statuses);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r WHERE r.status in :statuses")
+    List<Reservation> findAllByStatusInWithLock(Collection<ReservationStatus> statuses);
+
     List<Reservation> findAllByConcertSeatIdInAndStatusIn(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r WHERE r.concertSeatId in :concertSeatIds and r.status in :statuses")
+    List<Reservation> findAllByConcertSeatIdInAndStatusInWithLock(Collection<Long> concertSeatIds, Collection<ReservationStatus> statuses);
 }

--- a/src/main/java/io/hhplus/concert/app/concert/presenter/controller/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/app/concert/presenter/controller/ConcertController.java
@@ -96,6 +96,7 @@ public class ConcertController {
 
     @PatchMapping("/{concertId}/schedules/{concertScheduleId}/seats/{concertSeatId}/reservations/{reservationId}")
     public PurchaseResult purchase(
+            @RequestHeader("Authorization") String keyUuid,
             @PathVariable @Min(1) Long concertId,
             @PathVariable @Min(1) Long concertScheduleId,
             @PathVariable @Min(1) Long concertSeatId,
@@ -104,6 +105,7 @@ public class ConcertController {
     ) {
         PurchaseReservationUseCase.Output output = purchaseReservationUseCase.execute(
                 new PurchaseReservationUseCase.Input(
+                        keyUuid,
                         concertId,
                         concertScheduleId,
                         concertSeatId,

--- a/src/main/java/io/hhplus/concert/app/concert/usecase/ReleaseReservationsUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/concert/usecase/ReleaseReservationsUseCase.java
@@ -35,9 +35,7 @@ public class ReleaseReservationsUseCase {
 
     @Transactional
     public Output execute(Input input) {
-        // reservation -> payment 순서대로 비관락
-        // 다른 트랜잭션 블록에서 payment -> reservation 순서로 처리 시 데드락에 주의
-        List<Reservation> originReservations = reservationPort.getAllByStatusesWithLock(
+        List<Reservation> originReservations = reservationPort.getAllByStatuses(
                 List.of(ReservationStatus.PENDING)
         );
 
@@ -45,7 +43,7 @@ public class ReleaseReservationsUseCase {
             return new Output();
         }
 
-        List<Payment> payments = paymentPort.getExpiredAllByIdsWithLock(
+        List<Payment> payments = paymentPort.getExpiredAllByIds(
                 originReservations.stream().map(Reservation::getPaymentId).toList()
         );
 
@@ -61,7 +59,7 @@ public class ReleaseReservationsUseCase {
 
         reservations.forEach(Reservation::setCancelled);
 
-        List<ConcertSeat> seats = concertSeatPort.getAllByIdsWithLock(
+        List<ConcertSeat> seats = concertSeatPort.getAllByIds(
                 reservations.stream().map(Reservation::getConcertSeatId).toList());
         seats.forEach(ConcertSeat::open);
 

--- a/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
@@ -54,7 +54,7 @@ public class ReservationSeatUseCase {
         concertPort.existsOrThrow(input.concertId());
         concertSchedulePort.existsOrThrow(input.concertScheduleId());
 
-        ConcertSeat seat = concertSeatPort.getWithLock(input.concertSeatId());
+        ConcertSeat seat = concertSeatPort.get(input.concertSeatId());
         if (seat.isClosed()) {
             log.info("예약된 좌석에 예약 시도: uuid = {}, concertSeatId = {}", token.getKeyUuid(), seat.getId());
             throw new IllegalStateException("이미 예약된 좌석: " + seat.getId());

--- a/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
@@ -13,15 +13,13 @@ import io.hhplus.concert.app.payment.domain.enm.PaymentStatus;
 import io.hhplus.concert.app.payment.port.PaymentPort;
 import io.hhplus.concert.app.user.domain.Token;
 import io.hhplus.concert.app.user.port.TokenPort;
+import io.hhplus.concert.config.aop.annotation.RedisLock;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 
 @Slf4j
 @AllArgsConstructor
@@ -46,6 +44,7 @@ public class ReservationSeatUseCase {
             ReservationResult reservationResult
     ) { }
 
+    @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
     @Transactional
     public Output execute(Input input) {
 

--- a/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java
@@ -45,7 +45,6 @@ public class ReservationSeatUseCase {
     ) { }
 
     @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
-    @Transactional
     public Output execute(Input input) {
 
         Token token = tokenPort.getByKey(input.keyUuid());

--- a/src/main/java/io/hhplus/concert/app/concert/usecase/SearchAvailableSeatsUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/concert/usecase/SearchAvailableSeatsUseCase.java
@@ -44,8 +44,7 @@ public class SearchAvailableSeatsUseCase {
             throw new NoSuchElementException("Concert Schedule not found: " + input.concertScheduleId());
         }
 
-        // ** 원래는 낙관락 사용해야 하는 부분.
-        List<ConcertSeat> seats = concertSeatPort.getAllByConcertScheduleIdWithLock(input.concertScheduleId());
+        List<ConcertSeat> seats = concertSeatPort.getAllByConcertScheduleId(input.concertScheduleId());
 
         return new Output(
                 seats.stream().map(

--- a/src/main/java/io/hhplus/concert/app/payment/port/PaymentPort.java
+++ b/src/main/java/io/hhplus/concert/app/payment/port/PaymentPort.java
@@ -54,11 +54,19 @@ public class PaymentPort {
         jpaRepository.delete(payment);
     }
 
-    public List<Payment> getExpiredAllByIdsWithLock(List<Long> ids) {
+    public List<Payment> getExpiredAllByIds(List<Long> ids) {
         return jpaRepository.findAllByIdInAndDueAtLessThan(ids, LocalDateTime.now());
     }
 
-    public List<Payment> getAvailableAllByIdsWithLock(List<Long> ids) {
+    public List<Payment> getExpiredAllByIdsWithLock(List<Long> ids) {
+        return jpaRepository.findAllByIdInAndDueAtLessThanWithLock(ids, LocalDateTime.now());
+    }
+
+    public List<Payment> getAvailableAllByIds(List<Long> ids) {
         return jpaRepository.findAllByIdInAndDueAtGreaterThanEqual(ids, LocalDateTime.now());
+    }
+
+    public List<Payment> getAvailableAllByIdsWithLock(List<Long> ids) {
+        return jpaRepository.findAllByIdInAndDueAtGreaterThanEqualWithLock(ids, LocalDateTime.now());
     }
 }

--- a/src/main/java/io/hhplus/concert/app/payment/port/jpa/PaymentJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/payment/port/jpa/PaymentJpaRepository.java
@@ -15,19 +15,25 @@ import java.util.Optional;
 @Repository
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
 
-    Optional<Payment> findByPaymentKey(String paymentKey);
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Payment p WHERE p.id = :id")
     Optional<Payment> findByIdWithLock(Long id);
+
+    Optional<Payment> findByPaymentKey(String paymentKey);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Payment p WHERE p.paymentKey = :paymentKey")
     Optional<Payment> findByPaymentKeyWithLock(String paymentKey);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<Payment> findAllByIdInAndDueAtLessThan(Collection<Long> ids, LocalDateTime baseDateTime);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.id in :ids and p.dueAt < :baseDateTime")
+    List<Payment> findAllByIdInAndDueAtLessThanWithLock(Collection<Long> ids, LocalDateTime baseDateTime);
+
     List<Payment> findAllByIdInAndDueAtGreaterThanEqual(Collection<Long> ids, LocalDateTime baseDateTime);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.id in :ids and p.dueAt >= :baseDateTime")
+    List<Payment> findAllByIdInAndDueAtGreaterThanEqualWithLock(Collection<Long> ids, LocalDateTime baseDateTime);
 }

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
@@ -14,6 +14,7 @@ import io.hhplus.concert.app.user.domain.UserPoint;
 import io.hhplus.concert.app.user.domain.enm.PointTransactionType;
 import io.hhplus.concert.app.user.port.PointTransactionPort;
 import io.hhplus.concert.app.user.port.UserPointPort;
+import io.hhplus.concert.config.aop.annotation.RedisLock;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
@@ -43,6 +44,7 @@ public class CompleteChargeUserPointUseCase {
             PointChangeResult pointChangeResult
     ) { }
 
+    @RedisLock(key = "Point", dtoName = "input", fields = {"userId"})
     @Transactional
     public Output execute(Input input) {
         Payment payment = paymentPort.getByPaymentKey(input.paymentKey());

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
@@ -45,7 +45,7 @@ public class CompleteChargeUserPointUseCase {
 
     @Transactional
     public Output execute(Input input) {
-        Payment payment = paymentPort.getByPaymentKeyWithLock(input.paymentKey());
+        Payment payment = paymentPort.getByPaymentKey(input.paymentKey());
         switch (payment.getStatus()) {
             case PAID -> {
                 log.debug("이미 완료된 결제: paymentId = {}", payment.getId());
@@ -67,7 +67,7 @@ public class CompleteChargeUserPointUseCase {
             throw new IllegalArgumentException("결제 기한 만료");
         }
 
-        UserPoint userPoint = userPointPort.getByUserIdWithLock(input.userId());
+        UserPoint userPoint = userPointPort.getByUserId(input.userId());
 
         PgResultType result = hangHaePgPort.purchase(
                 payment.getUserId(),

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
@@ -36,6 +36,7 @@ public class CompleteChargeUserPointUseCase {
     private final PointTransactionPort pointTransactionPort;
 
     public record Input(
+            String keyUuid,
             Long userId,
             String paymentKey
     ) { }
@@ -44,7 +45,7 @@ public class CompleteChargeUserPointUseCase {
             PointChangeResult pointChangeResult
     ) { }
 
-    @RedisLock(key = "Point", dtoName = "input", fields = {"userId"})
+    @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
     @Transactional
     public Output execute(Input input) {
         Payment payment = paymentPort.getByPaymentKey(input.paymentKey());

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java
@@ -46,7 +46,6 @@ public class CompleteChargeUserPointUseCase {
     ) { }
 
     @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
-    @Transactional
     public Output execute(Input input) {
         Payment payment = paymentPort.getByPaymentKey(input.paymentKey());
         switch (payment.getStatus()) {

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
@@ -29,6 +29,7 @@ public class PendingChargeUserPointUseCase {
     private final PointTransactionPort pointTransactionPort;
 
     public record Input(
+            String keyUuid,
             Long userId,
             BigDecimal amount
     ) { }
@@ -37,7 +38,7 @@ public class PendingChargeUserPointUseCase {
             PendingPointChargeResult pendingPointChargeResult
     ) { }
 
-    @RedisLock(key = "Point", dtoName = "input", fields = {"userId"})
+    @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
     @Transactional
     public Output execute(Input input) {
         UserPoint userPoint = userPointPort.getByUserId(input.userId());

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
@@ -10,10 +10,9 @@ import io.hhplus.concert.app.user.domain.enm.PointTransactionStatus;
 import io.hhplus.concert.app.user.domain.enm.PointTransactionType;
 import io.hhplus.concert.app.user.port.PointTransactionPort;
 import io.hhplus.concert.app.user.port.UserPointPort;
+import io.hhplus.concert.config.aop.annotation.RedisLock;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +37,7 @@ public class PendingChargeUserPointUseCase {
             PendingPointChargeResult pendingPointChargeResult
     ) { }
 
+    @RedisLock(key = "Point", dtoName = "input", fields = {"userId"})
     @Transactional
     public Output execute(Input input) {
         UserPoint userPoint = userPointPort.getByUserId(input.userId());

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
@@ -40,7 +40,7 @@ public class PendingChargeUserPointUseCase {
 
     @Transactional
     public Output execute(Input input) {
-        UserPoint userPoint = userPointPort.getByUserIdWithLock(input.userId());
+        UserPoint userPoint = userPointPort.getByUserId(input.userId());
 
         Payment payment = paymentPort.save(
                 Payment.builder()

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java
@@ -39,7 +39,6 @@ public class PendingChargeUserPointUseCase {
     ) { }
 
     @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
-    @Transactional
     public Output execute(Input input) {
         UserPoint userPoint = userPointPort.getByUserId(input.userId());
 

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
@@ -56,9 +56,7 @@ public class PurchaseReservationUseCase {
             PurchaseResult purchaseResult
     ) { }
 
-//    @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
     @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
-    @Transactional
     public Output execute(Input input) {
 
         concertPort.existsOrThrow(input.concertId());

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
@@ -63,10 +63,8 @@ public class PurchaseReservationUseCase {
         concertSchedulePort.existsOrThrow(input.concertScheduleId());
         concertSeatPort.existsOrThrow(input.concertSeatId());
 
-        // reservation -> payment 순서대로 비관락
-        // 다른 트랜잭션 블록에서 payment -> reservation 순서로 처리 시 데드락에 주의
-        Reservation reservation = reservationPort.getWithLock(input.reservationId());
-        Payment payment = paymentPort.getByPaymentKeyWithLock(input.paymentKey());
+        Reservation reservation = reservationPort.get(input.reservationId());
+        Payment payment = paymentPort.getByPaymentKey(input.paymentKey());
         if (!Objects.equals(reservation.getPaymentId(), payment.getId())) {
             log.warn("유효하지 않은 결제 키 요청: {} != {}({})",
                     reservation.getPaymentId(), payment.getId(), payment.getPaymentKey());
@@ -84,8 +82,7 @@ public class PurchaseReservationUseCase {
             }
         }
 
-        // 비관락을 걸어야 동시에 접근 시 보유 포인트에 대한 정상적인 차감이 보장됨
-        UserPoint userPoint = userPointPort.getByUserIdWithLock(reservation.getUserId());
+        UserPoint userPoint = userPointPort.getByUserId(reservation.getUserId());
         if (!userPoint.isEnough(payment.getPrice())) {
             log.debug("잔여 포인트 부족: userId = {}, remains = {} < amount = {}", userPoint.getUserId(), userPoint.getRemains(), payment.getPrice());
             throw new IllegalStateException("잔여 포인트 부족: (remains = " + userPoint.getRemains() + " < amount = " + payment.getPrice() + ")");

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
@@ -19,10 +19,9 @@ import io.hhplus.concert.app.user.domain.enm.PointTransactionStatus;
 import io.hhplus.concert.app.user.domain.enm.PointTransactionType;
 import io.hhplus.concert.app.user.port.PointTransactionPort;
 import io.hhplus.concert.app.user.port.UserPointPort;
+import io.hhplus.concert.config.aop.annotation.RedisLock;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +55,7 @@ public class PurchaseReservationUseCase {
             PurchaseResult purchaseResult
     ) { }
 
+    @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
     @Transactional
     public Output execute(Input input) {
 

--- a/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java
@@ -43,6 +43,7 @@ public class PurchaseReservationUseCase {
     private final PointTransactionPort pointTransactionPort;
 
     public record Input(
+            String keyUuid,
             Long concertId,
             Long concertScheduleId,
             Long concertSeatId,
@@ -55,7 +56,8 @@ public class PurchaseReservationUseCase {
             PurchaseResult purchaseResult
     ) { }
 
-    @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
+//    @RedisLock(key = "Reservation", dtoName = "input", fields = {"concertId", "concertScheduleId", "concertSeatId"})
+    @RedisLock(key = "Point", dtoName = "input", fields = {"keyUuid"})
     @Transactional
     public Output execute(Input input) {
 

--- a/src/main/java/io/hhplus/concert/app/user/port/PointTransactionPort.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/PointTransactionPort.java
@@ -19,8 +19,12 @@ public class PointTransactionPort {
         return jpaRepository.findByPaymentId(paymentId).orElseThrow();
     }
 
-    public List<PointTransaction> getAllByStatusesWithLock(Collection<PointTransactionStatus> statuses) {
+    public List<PointTransaction> getAllByStatuses(Collection<PointTransactionStatus> statuses) {
         return jpaRepository.findAllByStatusIn(statuses);
+    }
+
+    public List<PointTransaction> getAllByStatusesWithLock(Collection<PointTransactionStatus> statuses) {
+        return jpaRepository.findAllByStatusInWithLock(statuses);
     }
 
     public PointTransaction save(PointTransaction pointTransaction) {

--- a/src/main/java/io/hhplus/concert/app/user/port/ServiceEntryPort.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/ServiceEntryPort.java
@@ -36,6 +36,10 @@ public class ServiceEntryPort {
         return jpaRepository.getEntryRankByTokenId(tokenId);
     }
 
+    public List<Long> findEnrollableAllTokenIdByTop30() {
+        return jpaRepository.findAllTokenIdByOrderByEntryAtTop(PageRequest.of(0, 30));
+    }
+
     public List<Long> findEnrollableAllTokenIdByTop30WithLock() {
         return jpaRepository.findAllTokenIdByOrderByEntryAtTopWithLock(PageRequest.of(0, 30));
     }
@@ -44,8 +48,12 @@ public class ServiceEntryPort {
         jpaRepository.updateAllByTokenIdIn(tokenIds, LocalDateTime.now());
     }
 
-    public List<Long> findAllTokenIdExpiredWithLock() {
+    public List<Long> findAllTokenIdExpired() {
         return jpaRepository.findAllTokenIdByEnrolledAtLessThan(LocalDateTime.now().minusMinutes(10L));
+    }
+
+    public List<Long> findAllTokenIdExpiredWithLock() {
+        return jpaRepository.findAllTokenIdByEnrolledAtLessThanWithLock(LocalDateTime.now().minusMinutes(10L));
     }
 
     public void delete(Long tokenId) {

--- a/src/main/java/io/hhplus/concert/app/user/port/TokenPort.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/TokenPort.java
@@ -38,8 +38,12 @@ public class TokenPort {
         return jpaRepository.save(token);
     }
 
-    public List<Long> findAllIdsExpiredWithLock() {
+    public List<Long> findAllIdsExpired() {
         return jpaRepository.findAllIdsByExpiresAtLessThan(LocalDateTime.now());
+    }
+
+    public List<Long> findAllIdsExpiredWithLock() {
+        return jpaRepository.findAllIdsByExpiresAtLessThanWithLock(LocalDateTime.now());
     }
 
     public void deleteAll(Iterable<Token> tokens) {

--- a/src/main/java/io/hhplus/concert/app/user/port/jpa/PointTransactionJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/jpa/PointTransactionJpaRepository.java
@@ -5,6 +5,7 @@ import io.hhplus.concert.app.user.domain.enm.PointTransactionStatus;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -14,8 +15,11 @@ import java.util.Optional;
 @Repository
 public interface PointTransactionJpaRepository extends JpaRepository<PointTransaction, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<PointTransaction> findAllByStatusIn(Collection<PointTransactionStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select pt from PointTransaction pt where pt.status in :statuses")
+    List<PointTransaction> findAllByStatusInWithLock(Collection<PointTransactionStatus> statuses);
 
     Optional<PointTransaction> findByPaymentId(Long paymentId);
 }

--- a/src/main/java/io/hhplus/concert/app/user/port/jpa/ServiceEntryJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/jpa/ServiceEntryJpaRepository.java
@@ -18,15 +18,20 @@ import java.util.Optional;
 @Repository
 public interface ServiceEntryJpaRepository extends JpaRepository<ServiceEntry, Long> {
 
+    List<Long> findAllTokenIdByEnrolledAtLessThan(LocalDateTime baseDateTime);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e.tokenId FROM ServiceEntry e WHERE e.enrolledAt < :baseDateTime")
-    List<Long> findAllTokenIdByEnrolledAtLessThan(LocalDateTime baseDateTime);
+    List<Long> findAllTokenIdByEnrolledAtLessThanWithLock(LocalDateTime baseDateTime);
 
     void deleteByTokenId(Long tokenId);
     void deleteAllByTokenIdIn(Collection<Long> tokenIds);
 
     Optional<ServiceEntry> findByTokenId(Long tokenId);
     Boolean existsByTokenId(Long tokenId);
+
+    @Query("SELECT e.tokenId FROM ServiceEntry e WHERE e.enrolledAt IS NULL ORDER BY e.entryAt ASC")
+    List<Long> findAllTokenIdByOrderByEntryAtTop(Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e.tokenId FROM ServiceEntry e WHERE e.enrolledAt IS NULL ORDER BY e.entryAt ASC")

--- a/src/main/java/io/hhplus/concert/app/user/port/jpa/TokenJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/user/port/jpa/TokenJpaRepository.java
@@ -24,7 +24,9 @@ public interface TokenJpaRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByUserId(Long userId);
 
+    List<Long> findAllIdsByExpiresAtLessThan(LocalDateTime baseDateTime);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t.id FROM Token t WHERE t.expiresAt < :baseDateTime")
-    List<Long> findAllIdsByExpiresAtLessThan(LocalDateTime baseDateTime);
+    List<Long> findAllIdsByExpiresAtLessThanWithLock(LocalDateTime baseDateTime);
 }

--- a/src/main/java/io/hhplus/concert/app/user/presenter/controller/UserController.java
+++ b/src/main/java/io/hhplus/concert/app/user/presenter/controller/UserController.java
@@ -51,11 +51,13 @@ public class UserController {
 
     @PostMapping("/{userId}/points/pending")
     public PendingPointChargeResult pendingChargeUserPoint(
+            @RequestHeader("Authorization") String keyUuid,
             @PathVariable @Min(1) Long userId,
             @RequestBody ChargePointResult requestBody
     ) {
         PendingChargeUserPointUseCase.Output output = pendingChargeUserPointUseCase.execute(
                 new PendingChargeUserPointUseCase.Input(
+                        keyUuid,
                         userId,
                         requestBody.chargeAmount()
                 )
@@ -65,11 +67,13 @@ public class UserController {
 
     @PatchMapping("/{userId}/points")
     public PointChangeResult completeChargeUserPoint(
+            @RequestHeader("Authorization") String keyUuid,
             @PathVariable @Min(1) Long userId,
             @RequestParam String paymentKey
     ) {
         CompleteChargeUserPointUseCase.Output output = completeChargeUserPointUseCase.execute(
                 new CompleteChargeUserPointUseCase.Input(
+                        keyUuid,
                         userId,
                         paymentKey
                 )

--- a/src/main/java/io/hhplus/concert/app/user/usecase/QueueEjectUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/user/usecase/QueueEjectUseCase.java
@@ -29,10 +29,10 @@ public class QueueEjectUseCase {
     @Transactional
     public Output execute(Input input) {
         // 토큰이 만료된 이용자 토큰 ID
-        List<Long> expiredTokens = tokenPort.findAllIdsExpiredWithLock();
+        List<Long> expiredTokens = tokenPort.findAllIdsExpired();
 
         // 등록 후 10분이 지난 이용자 토큰 ID
-        List<Long> expiredEnrolls = serviceEntryPort.findAllTokenIdExpiredWithLock();
+        List<Long> expiredEnrolls = serviceEntryPort.findAllTokenIdExpired();
 
         List<Long> ejectTargets = Stream.concat(
                 expiredTokens.stream(),

--- a/src/main/java/io/hhplus/concert/app/user/usecase/QueueEnrollUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/user/usecase/QueueEnrollUseCase.java
@@ -27,7 +27,7 @@ public class QueueEnrollUseCase {
     public Output execute(Input input) {
 
         // 등록 가능한 진입 이용자 토큰 ID (30명)
-        List<Long> enrollableTokenIds = serviceEntryPort.findEnrollableAllTokenIdByTop30WithLock();
+        List<Long> enrollableTokenIds = serviceEntryPort.findEnrollableAllTokenIdByTop30();
 
         log.debug("Schedule: Enrolled: {}", enrollableTokenIds);
 

--- a/src/main/java/io/hhplus/concert/app/user/usecase/ReleasePointTransactionsUseCase.java
+++ b/src/main/java/io/hhplus/concert/app/user/usecase/ReleasePointTransactionsUseCase.java
@@ -32,9 +32,7 @@ public class ReleasePointTransactionsUseCase {
 
     @Transactional
     public Output execute(Input input) {
-        // reservation -> payment 순서대로 비관락
-        // 다른 트랜잭션 블록에서 payment -> reservation 순서로 처리 시 데드락에 주의
-        List<PointTransaction> originPointTransactions = pointTransactionPort.getAllByStatusesWithLock(
+        List<PointTransaction> originPointTransactions = pointTransactionPort.getAllByStatuses(
                 List.of(PointTransactionStatus.PENDING)
         );
 
@@ -42,7 +40,7 @@ public class ReleasePointTransactionsUseCase {
             return new Output();
         }
 
-        List<Payment> payments = paymentPort.getExpiredAllByIdsWithLock(
+        List<Payment> payments = paymentPort.getExpiredAllByIds(
                 originPointTransactions.stream().map(PointTransaction::getPaymentId).toList()
         );
 

--- a/src/main/java/io/hhplus/concert/config/RedissonConfig.java
+++ b/src/main/java/io/hhplus/concert/config/RedissonConfig.java
@@ -1,0 +1,39 @@
+package io.hhplus.concert.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Objects;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${redisson.address}")
+    private String address;
+
+    @Value("${redisson.password}")
+    private String password;
+
+    @Value("${redisson.timeout}")
+    private Integer timeout;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        SingleServerConfig ssc = config.useSingleServer();
+        ssc.setAddress(address);
+        if (password != null && !password.isEmpty()) {
+            ssc.setPassword(password);
+        }
+        if (timeout != null && timeout > 0) {
+            ssc.setTimeout(timeout);
+        }
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/io/hhplus/concert/config/aop/RedisLockAspect.java
+++ b/src/main/java/io/hhplus/concert/config/aop/RedisLockAspect.java
@@ -1,0 +1,83 @@
+package io.hhplus.concert.config.aop;
+
+import io.hhplus.concert.config.aop.annotation.RedisLock;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.util.StringJoiner;
+
+@Slf4j
+@Component
+@Aspect
+@Order(1)  // @Transactional 어노테이션은 @Order(100)으로 설정되어 있어서 트랜잭션 보다 먼저 실행이 보장됨
+@AllArgsConstructor
+public class RedisLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(redisLock)")
+    public Object lockAndExecute(ProceedingJoinPoint joinPoint, RedisLock redisLock) throws Throwable {
+        Long threadId = Thread.currentThread().getId();
+
+        String key = redisLock.key() + ":" + getDynamicKey(joinPoint, redisLock.dtoName(), redisLock.fields());
+        log.info("Lock 취득 시도: thread-id = {}, key = {}", threadId, key);
+        RLock lock = redissonClient.getLock(key);
+        try {
+            lock.lock();
+            log.info("Lock 취득 성공: thread-id = {}, key = {}", threadId, key);
+            return joinPoint.proceed();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private String getDynamicKey(ProceedingJoinPoint joinPoint, String dtoName, String[] fields) throws NoSuchFieldException, IllegalAccessException {
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+
+        if (dtoName == null || dtoName.isEmpty()) {
+            // DTO가 없을 경우 메소드 매개변수에서 추출
+            StringJoiner joiner = new StringJoiner("&");
+            for (String fieldName : fields) {
+                boolean fieldFound = false;
+                for (int i = 0; i < paramNames.length; i++) {
+                    if (paramNames[i].equals(fieldName)) {
+                        joiner.add(String.valueOf(args[i]));
+                        fieldFound = true;
+                        break;
+                    }
+                }
+                if (!fieldFound) {
+                    throw new IllegalArgumentException("Field parameter not found: " + fieldName);
+                }
+            }
+            return joiner.toString();
+        } else {
+            // DTO가 존재할 경우 DTO 필드에서 추출
+            for (int i = 0; i < paramNames.length; i++) {
+                if (paramNames[i].equals(dtoName)) {
+                    Object param = args[i];
+
+                    StringJoiner joiner = new StringJoiner("&");
+                    for (String fieldName : fields) {
+                        Field field = param.getClass().getDeclaredField(fieldName);
+                        field.setAccessible(true);
+                        joiner.add(String.valueOf(field.get(param)));
+                    }
+
+                    return joiner.toString();
+                }
+            }
+            throw new IllegalArgumentException("Key parameter not found: " + dtoName);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/config/aop/RedisLockAspect.java
+++ b/src/main/java/io/hhplus/concert/config/aop/RedisLockAspect.java
@@ -30,11 +30,11 @@ public class RedisLockAspect {
         Long threadId = Thread.currentThread().getId();
 
         String key = redisLock.key() + ":" + getDynamicKey(joinPoint, redisLock.dtoName(), redisLock.fields());
-        log.info("Lock 취득 시도: thread-id = {}, key = {}", threadId, key);
+        log.debug("Lock 취득 시도: thread-id = {}, key = {}", threadId, key);
         RLock lock = redissonClient.getLock(key);
         try {
             lock.lock();
-            log.info("Lock 취득 성공: thread-id = {}, key = {}", threadId, key);
+            log.debug("Lock 취득 성공: thread-id = {}, key = {}", threadId, key);
             return transactionalJoinPoint.execute(joinPoint);
         } finally {
             lock.unlock();

--- a/src/main/java/io/hhplus/concert/config/aop/annotation/RedisLock.java
+++ b/src/main/java/io/hhplus/concert/config/aop/annotation/RedisLock.java
@@ -1,0 +1,14 @@
+package io.hhplus.concert.config.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisLock {
+    String key() default "default";
+    String dtoName() default "";
+    String[] fields() default {};
+}

--- a/src/main/java/io/hhplus/concert/config/aop/component/TransactionalJoinPoint.java
+++ b/src/main/java/io/hhplus/concert/config/aop/component/TransactionalJoinPoint.java
@@ -1,0 +1,13 @@
+package io.hhplus.concert.config.aop.component;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionalJoinPoint {
+    @Transactional
+    public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,3 +5,5 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+redisson:
+  address: redis://${redis.host}:${redis.port}/1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: false
+redis:
+  host: 127.0.0.1
+  port: 6379
+  password: ""
+  timeout: 3000
+redisson:
+  address: redis://${redis.host}:${redis.port}/0
+  password: ${redis.password}
+  timeout: ${redis.timeout}

--- a/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/CompleteChargeUserPointUseCaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/CompleteChargeUserPointUseCaseIntegrationTest.java
@@ -86,6 +86,8 @@ public class CompleteChargeUserPointUseCaseIntegrationTest {
     public void completeChargeUserPoint() {
         CompleteChargeUserPointUseCase.Output output = completeChargeUserPointUseCase.execute(
                 new CompleteChargeUserPointUseCase.Input(
+
+                        "99543f87-9280-45f8-9a56-84a3a3d1312b",
                         1L,
                         paymentKey
                 )

--- a/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/PendingChargeUserPointUseCaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/PendingChargeUserPointUseCaseIntegrationTest.java
@@ -53,6 +53,7 @@ public class PendingChargeUserPointUseCaseIntegrationTest {
     public void pendingChargeUserPoint() {
         PendingChargeUserPointUseCase.Output output = pendingChargeUserPointUseCase.execute(
                 new PendingChargeUserPointUseCase.Input(
+                        "99543f87-9280-45f8-9a56-84a3a3d1312b",
                         1L,
                         BigDecimal.valueOf(50000)
                 )

--- a/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/PurchaseReservationUseCaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/apps/integration/payment/usecase/PurchaseReservationUseCaseIntegrationTest.java
@@ -121,6 +121,7 @@ public class PurchaseReservationUseCaseIntegrationTest {
     public void purchaseReservation() {
         PurchaseReservationUseCase.Output output = purchaseReservationUseCase.execute(
                 new PurchaseReservationUseCase.Input(
+                        "99543f87-9280-45f8-9a56-84a3a3d1312b",
                         1L,
                         1L,
                         1L,

--- a/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/ReleaseReservationsUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/ReleaseReservationsUseCaseUnitTest.java
@@ -54,8 +54,8 @@ public class ReleaseReservationsUseCaseUnitTest {
     @Test
     @DisplayName("임시 상태인 예약이 없으면 다음 스텝으로 넘어가지 않는다")
     public void noPendingReservations() {
-        when(reservationPort.getAllByStatusesWithLock(any(List.class))).thenReturn(List.of());
-        lenient().when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).thenThrow(AssertionError.class);
+        when(reservationPort.getAllByStatuses(any(List.class))).thenReturn(List.of());
+        lenient().when(paymentPort.getExpiredAllByIds(any(List.class))).thenThrow(AssertionError.class);
 
         assertDoesNotThrow(() -> releaseReservationsUseCase.execute(new ReleaseReservationsUseCase.Input()));
     }
@@ -63,8 +63,8 @@ public class ReleaseReservationsUseCaseUnitTest {
     @Test
     @DisplayName("임시 상태의 예약이 있어도 만료된 결제 정보가 없으면 다음 스텝으로 넘어가지 않는다")
     public void noExpiredPayments() {
-        when(reservationPort.getAllByStatusesWithLock(any(List.class))).thenReturn(List.of(new Reservation()));
-        when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).thenReturn(List.of());
+        when(reservationPort.getAllByStatuses(any(List.class))).thenReturn(List.of(new Reservation()));
+        when(paymentPort.getExpiredAllByIds(any(List.class))).thenReturn(List.of());
         lenient().when(paymentPort.saveAll(any(List.class))).thenThrow(AssertionError.class);
 
         assertDoesNotThrow(() -> releaseReservationsUseCase.execute(new ReleaseReservationsUseCase.Input()));
@@ -73,7 +73,7 @@ public class ReleaseReservationsUseCaseUnitTest {
     @Test
     @DisplayName("만료된 결제정보가 존재하면 취소 상태로 변경한다")
     public void releaseExpiredPayments() {
-        when(reservationPort.getAllByStatusesWithLock(any(List.class))).then(r -> {
+        when(reservationPort.getAllByStatuses(any(List.class))).then(r -> {
             selectedReservations = new ArrayList<>();
             for (int i = 0; i < 5; i++) {
                 selectedReservations.add(
@@ -88,7 +88,7 @@ public class ReleaseReservationsUseCaseUnitTest {
             }
             return selectedReservations;
         });
-        when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).then(r -> {
+        when(paymentPort.getExpiredAllByIds(any(List.class))).then(r -> {
             selectedPayments = new ArrayList<>();
             for (int i = 0; i < 3; i++) {
                 selectedPayments.add(

--- a/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/ReservationSeatUseCaseUnitTest.java
@@ -84,7 +84,7 @@ public class ReservationSeatUseCaseUnitTest {
         lenient().when(tokenPort.getByKey(eq(keyUuid))).thenReturn(token);
         lenient().when(concertPort.existsById(any(Long.class))).thenReturn(true);
         lenient().when(concertSchedulePort.existsById(any(Long.class))).thenReturn(true);
-        lenient().when(concertSeatPort.getWithLock(any(Long.class))).thenReturn(concertSeat);
+        lenient().when(concertSeatPort.get(any(Long.class))).thenReturn(concertSeat);
         lenient().when(concertSeatPort.save(any(ConcertSeat.class))).thenReturn(concertSeat);
 
         lenient().when(paymentPort.save(any(Payment.class))).then(r -> {
@@ -173,7 +173,7 @@ public class ReservationSeatUseCaseUnitTest {
     @Test
     @DisplayName("좌석이 없으면 예외가 발생한다")
     public void noSeat() {
-        when(concertSeatPort.getWithLock(any(Long.class))).thenThrow(new NoSuchElementException("No value present"));
+        when(concertSeatPort.get(any(Long.class))).thenThrow(new NoSuchElementException("No value present"));
 
         NoSuchElementException e = assertThrows(
                 NoSuchElementException.class, () -> reservationSeatUseCase.execute(

--- a/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/SearchAvailableSeatsUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/concert/usecase/SearchAvailableSeatsUseCaseUnitTest.java
@@ -87,7 +87,7 @@ public class SearchAvailableSeatsUseCaseUnitTest {
     @DisplayName("유효한 콘서트 좌석을 조회한다")
     public void searchSchedules() {
 
-        when(concertSeatPort.getAllByConcertScheduleIdWithLock(eq(2L))).then(r -> {
+        when(concertSeatPort.getAllByConcertScheduleId(eq(2L))).then(r -> {
             List<ConcertSeat> items = new ArrayList<>();
             for (int i = 0; i < 50; i++) {
                 ConcertSeat item = ConcertSeat.builder()

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/CompleteChargeUserPointUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/CompleteChargeUserPointUseCaseUnitTest.java
@@ -129,6 +129,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 IllegalArgumentException.class,
                 () -> completeChargeUserPointUseCase.execute(
                         new CompleteChargeUserPointUseCase.Input(
+                                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                                 userId,
                                 paymentKey
                         )
@@ -147,6 +148,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 IllegalArgumentException.class,
                 () -> completeChargeUserPointUseCase.execute(
                         new CompleteChargeUserPointUseCase.Input(
+                                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                                 userId,
                                 paymentKey
                         )
@@ -173,6 +175,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 IllegalArgumentException.class,
                 () -> completeChargeUserPointUseCase.execute(
                         new CompleteChargeUserPointUseCase.Input(
+                                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                                 userId,
                                 paymentKey
                         )
@@ -191,6 +194,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 AccessDeniedException.class,
                 () -> completeChargeUserPointUseCase.execute(
                         new CompleteChargeUserPointUseCase.Input(
+                                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                                 userId,
                                 paymentKey
                         )
@@ -205,6 +209,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
     public void completePayment() {
         CompleteChargeUserPointUseCase.Output output = completeChargeUserPointUseCase.execute(
                 new CompleteChargeUserPointUseCase.Input(
+                        "99543f87-9280-45f8-9a56-84a3a3d1312b",
                         userId,
                         paymentKey
                 )

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/CompleteChargeUserPointUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/CompleteChargeUserPointUseCaseUnitTest.java
@@ -99,11 +99,11 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 .paymentId(payment.getId())
                 .build();
 
-        lenient().when(paymentPort.getByPaymentKeyWithLock(eq(paymentKey))).thenReturn(payment);
+        lenient().when(paymentPort.getByPaymentKey(eq(paymentKey))).thenReturn(payment);
         lenient().when(hangHaePgPort.purchase(eq(userId), eq(paymentKey), any(BigDecimal.class))).thenReturn(PgResultType.OK);
         lenient().when(pointTransactionPort.getByPaymentId(eq(payment.getId()))).thenReturn(pointTransaction);
         lenient().when(pointTransactionPort.save(eq(pointTransaction))).thenReturn(pointTransaction);
-        lenient().when(userPointPort.getByUserIdWithLock(eq(userId))).thenReturn(userPoint);
+        lenient().when(userPointPort.getByUserId(eq(userId))).thenReturn(userPoint);
         lenient().when(userPointPort.save(eq(userPoint))).thenReturn(userPoint);
         lenient().when(paymentPort.save(eq(payment))).thenReturn(payment);
         lenient().when(paymentTransactionPort.save(any(PaymentTransaction.class))).then(r -> {
@@ -167,7 +167,7 @@ public class CompleteChargeUserPointUseCaseUnitTest {
                 .dueAt(LocalDateTime.now().minusMinutes(5))  // expired
                 .price(payment.getPrice())
                 .build();
-        when(paymentPort.getByPaymentKeyWithLock(eq(paymentKey))).thenReturn(expiredPayment);
+        when(paymentPort.getByPaymentKey(eq(paymentKey))).thenReturn(expiredPayment);
 
         IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PendingChargeUserPointUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PendingChargeUserPointUseCaseUnitTest.java
@@ -93,6 +93,7 @@ public class PendingChargeUserPointUseCaseUnitTest {
 
         pendingChargeUserPointUseCase.execute(
                 new PendingChargeUserPointUseCase.Input(
+                        "99543f87-9280-45f8-9a56-84a3a3d1312b",
                         userId,
                         BigDecimal.valueOf(5000)
                 )

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PendingChargeUserPointUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PendingChargeUserPointUseCaseUnitTest.java
@@ -63,7 +63,7 @@ public class PendingChargeUserPointUseCaseUnitTest {
     @Test
     @DisplayName("포인트 충전을 요청하면 포인트 거래 정보가 생성된다")
     public void createPointTransaction() {
-        when(userPointPort.getByUserIdWithLock(eq(userPoint.getUserId()))).thenReturn(userPoint);
+        when(userPointPort.getByUserId(eq(userPoint.getUserId()))).thenReturn(userPoint);
         when(paymentPort.save(any(Payment.class))).then(r -> {
             Payment origin = r.getArgument(0);
             return createdPayment = Payment.builder()

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PurchaseReservationUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PurchaseReservationUseCaseUnitTest.java
@@ -74,6 +74,7 @@ public class PurchaseReservationUseCaseUnitTest {
     public void setUp() {
         paymentKey = UUID.randomUUID().toString();
         input = new PurchaseReservationUseCase.Input(
+                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                 1L,
                 3L,
                 127L,
@@ -159,6 +160,7 @@ public class PurchaseReservationUseCaseUnitTest {
                 IllegalArgumentException.class,
                 () -> purchaseReservationUseCase.execute(
                         new PurchaseReservationUseCase.Input(
+                                "99543f87-9280-45f8-9a56-84a3a3d1312b",
                                 input.concertId(),
                                 input.concertScheduleId(),
                                 input.concertSeatId(),

--- a/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PurchaseReservationUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/payment/usecase/PurchaseReservationUseCaseUnitTest.java
@@ -107,9 +107,9 @@ public class PurchaseReservationUseCaseUnitTest {
         lenient().when(concertPort.existsById(any(Long.class))).thenReturn(true);
         lenient().when(concertSchedulePort.existsById(any(Long.class))).thenReturn(true);
         lenient().when(concertSeatPort.existsById(any(Long.class))).thenReturn(true);
-        lenient().when(reservationPort.getWithLock(eq(reservation.getId()))).thenReturn(reservation);
-        lenient().when(paymentPort.getByPaymentKeyWithLock(eq(paymentKey))).thenReturn(payment);
-        lenient().when(userPointPort.getByUserIdWithLock(eq(userPoint.getUserId()))).thenReturn(userPoint);
+        lenient().when(reservationPort.get(eq(reservation.getId()))).thenReturn(reservation);
+        lenient().when(paymentPort.getByPaymentKey(eq(paymentKey))).thenReturn(payment);
+        lenient().when(userPointPort.getByUserId(eq(userPoint.getUserId()))).thenReturn(userPoint);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class PurchaseReservationUseCaseUnitTest {
     @DisplayName("예약 정보와 맞지 않은 결제 키를 사용하면 예외가 발생한다")
     public void noMatchPaymentKey() {
         String differentPaymentKey = UUID.randomUUID().toString();
-        when(paymentPort.getByPaymentKeyWithLock(eq(differentPaymentKey))).then(r ->
+        when(paymentPort.getByPaymentKey(eq(differentPaymentKey))).then(r ->
                 Payment.builder()
                         .id(1280L)
                         .paymentKey(differentPaymentKey).build()

--- a/src/test/java/io/hhplus/concert/apps/unit/user/usecase/QueueEjectUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/user/usecase/QueueEjectUseCaseUnitTest.java
@@ -43,8 +43,8 @@ public class QueueEjectUseCaseUnitTest {
     @Test
     @DisplayName("이용자를 대기열에서 방출할 때 병합된 토큰 ID 배열에는 중복된 ID가 없어야 한다")
     public void ejectMergedTokens() {
-        when(tokenPort.findAllIdsExpiredWithLock()).thenReturn(List.of(1L,2L,3L,4L,5L,6L));
-        when(serviceEntryPort.findAllTokenIdExpiredWithLock()).thenReturn(List.of(3L,5L,7L,9L,11L));
+        when(tokenPort.findAllIdsExpired()).thenReturn(List.of(1L,2L,3L,4L,5L,6L));
+        when(serviceEntryPort.findAllTokenIdExpired()).thenReturn(List.of(3L,5L,7L,9L,11L));
         doAnswer(i -> {
             ejected.addAll(i.getArgument(0));
             return null;

--- a/src/test/java/io/hhplus/concert/apps/unit/user/usecase/QueueEnrollUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/user/usecase/QueueEnrollUseCaseUnitTest.java
@@ -38,7 +38,7 @@ public class QueueEnrollUseCaseUnitTest {
     @Test
     @DisplayName("대기열에 등록된 이용자 중 가장 빠른 30명을 서비스에 진입시킨다")
     public void enrollTokens() {
-        when(serviceEntryPort.findEnrollableAllTokenIdByTop30WithLock()).thenReturn(List.of(11L,12L,13L,14L,15L,16L));
+        when(serviceEntryPort.findEnrollableAllTokenIdByTop30()).thenReturn(List.of(11L,12L,13L,14L,15L,16L));
         doAnswer(i -> {
             enrolled.addAll(i.getArgument(0));
             return null;

--- a/src/test/java/io/hhplus/concert/apps/unit/user/usecase/ReleasePointTransactionsUseCaseUnitTest.java
+++ b/src/test/java/io/hhplus/concert/apps/unit/user/usecase/ReleasePointTransactionsUseCaseUnitTest.java
@@ -87,8 +87,8 @@ public class ReleasePointTransactionsUseCaseUnitTest {
     @Test
     @DisplayName("대기중인 포인트 거래내역이 없으면 다음 스텝으로 넘어가지 않아야 한다")
     public void noAvailablePendingPointTransactions() {
-        when(pointTransactionPort.getAllByStatusesWithLock(any(List.class))).thenReturn(List.of());
-        lenient().when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).thenThrow(AssertionError.class);
+        when(pointTransactionPort.getAllByStatuses(any(List.class))).thenReturn(List.of());
+        lenient().when(paymentPort.getExpiredAllByIds(any(List.class))).thenThrow(AssertionError.class);
 
         assertDoesNotThrow(
                 () -> releasePointTransactionsUseCase.execute(new ReleasePointTransactionsUseCase.Input())
@@ -98,8 +98,8 @@ public class ReleasePointTransactionsUseCaseUnitTest {
     @Test
     @DisplayName("대기중인 포인트 거래내역이 있지만 만료된 결제정보가 존재하지 않으면 다음 스텝으로 넘어가지 않아야 한다")
     public void noAvailableExpiredPayment() {
-        when(pointTransactionPort.getAllByStatusesWithLock(any(List.class))).then(r -> selectedPointTransactions);
-        when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).thenReturn(List.of());
+        when(pointTransactionPort.getAllByStatuses(any(List.class))).then(r -> selectedPointTransactions);
+        when(paymentPort.getExpiredAllByIds(any(List.class))).thenReturn(List.of());
         lenient().when(paymentPort.saveAll(any(List.class))).thenThrow(AssertionError.class);
 
         assertDoesNotThrow(
@@ -110,8 +110,8 @@ public class ReleasePointTransactionsUseCaseUnitTest {
     @Test
     @DisplayName("만료된 결제 정보가 존재하면 해당 결제 정보에 연결된 포인트 거래내역만 취소 처리 한다.")
     public void cancelExpired() {
-        when(pointTransactionPort.getAllByStatusesWithLock(any(List.class))).then(r -> selectedPointTransactions);
-        when(paymentPort.getExpiredAllByIdsWithLock(any(List.class))).then(r -> selectedPayments);
+        when(pointTransactionPort.getAllByStatuses(any(List.class))).then(r -> selectedPointTransactions);
+        when(paymentPort.getExpiredAllByIds(any(List.class))).then(r -> selectedPayments);
         when(pointTransactionPort.saveAll(any(List.class))).then(r -> {
             List<PointTransaction> result = r.getArgument(0);
             savedPointTransactions.addAll(result);


### PR DESCRIPTION
### STEP 12
- [x] DB Lock 을 활용한 동시성 제어 방식 에서 해당 비즈니스 로직에서 적합하다고 판단하여 차용한 동시성 제어 방식을 구현하여 비즈니스 로직에 적용하고, 통합테스트 등으로 이를 검증하는 코드 작성 및 제출

### 리뷰 포인트
- [`application.yml`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/pull/15/files#diff-ddebd657255d1b279b4a97038254d040d5d1d6e84a99627919463066b9a4a89c)와 [`application-test.yml`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/pull/15/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d)에서 서로 redis의 다른 db를 바라보게 해서 환경을 분리했습니다 (운영 0, 테스트 1)
- [Annotation](https://github.com/hyeondong-hong/hhplus-cocert-jvm/pull/15/files#diff-2bbdd7dde98cddf9cc7b040ab2eb0f5f0144d8e67c40b299becaebaad6d40cd2)과 [Aspect](https://github.com/hyeondong-hong/hhplus-cocert-jvm/pull/15/files#diff-f16d965f38ae8c09e3c70f5764bb3e777373c87712474789f0e4d21fa9aa1374)를 이용해 [`@RedisLock`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/feat/step12/src/main/java/io/hhplus/concert/config/aop/annotation/RedisLock.java) 어노테이션 클래스를 구현하여 AOP를 통해 레디스의 분산락이 적용되도록 구현했습니다
- `@RedisLock` 어노테이션은 내부적으로 `@Transactional` 어노테이션이 걸린 [`TransactionalJoinPoint`](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/feat/step12/src/main/java/io/hhplus/concert/config/aop/component/TransactionalJoinPoint.java) 클래스를 호출해서 처리하는 방식으로, 항상 락이 먼저 걸린 뒤 트랜잭션 수행 후 트랜잭션이 종료되면 락이 해제되는 구조로 설계했습니다
- 각각 예약과 포인트 이용 영역에서 적절하게 경합이 일어날 수 있도록 스코프에 대한 고정키와 매개변수 값을 조합한 동적인 키를 통해 분산락이 이뤄지도록 구성했습니다
  - 예약: [좌석 예약](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/c8cf3ff3227562ed0621470432df05c4390b659e/src/main/java/io/hhplus/concert/app/concert/usecase/ReservationSeatUseCase.java#L47)
  - 포인트: [포인트 충전 대기](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/c8cf3ff3227562ed0621470432df05c4390b659e/src/main/java/io/hhplus/concert/app/payment/usecase/PendingChargeUserPointUseCase.java#L41), [포인트 충전 완료](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/c8cf3ff3227562ed0621470432df05c4390b659e/src/main/java/io/hhplus/concert/app/payment/usecase/CompleteChargeUserPointUseCase.java#L48), [포인트 사용](https://github.com/hyeondong-hong/hhplus-cocert-jvm/blob/c8cf3ff3227562ed0621470432df05c4390b659e/src/main/java/io/hhplus/concert/app/payment/usecase/PurchaseReservationUseCase.java#L59)
  - 같은 예약에 대한 락이지만 정상적으로 각 좌석에 대해 동시에 락을 획득하는 로그의 스크린샷
  - <img width="393" alt="redis-lock" src="https://github.com/user-attachments/assets/04ab0cfb-3566-41b1-a2d1-afb777b71525">


### 질문사항
- 분산 락은 일부 범위가 명확한 케이스에 대해서는 확실하게 락을 걸 수 있는데, 전역적으로 락을 걸려면 어떤 전략을 취해야 할지 궁금합니다!
